### PR TITLE
feat(light): add kelvin properties, turn_on parameter, and on_kelvin_change decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Available events per domain:
 | Domain          | Events                                                                 |
 | --------------- | ---------------------------------------------------------------------- |
 | `MediaPlayer`   | `on_volume_change`, `on_mute_change`, `on_media_change`, `on_play`, `on_pause`, `on_stop` |
-| `Light`         | `on_turn_on`, `on_turn_off`, `on_brightness_change`, `on_color_change` |
+| `Light`         | `on_turn_on`, `on_turn_off`, `on_brightness_change`, `on_color_change`, `on_kelvin_change` |
 | `Switch`        | `on_turn_on`, `on_turn_off`                                            |
 | `BinarySensor`  | `on_turn_on`, `on_turn_off`                                            |
 | `Cover`         | `on_open`, `on_close`, `on_position_change`                            |

--- a/docs/light.md
+++ b/docs/light.md
@@ -11,12 +11,15 @@ Inherits from [`Entity`](base.md#ha_cliententityentity).
 | `is_on` | `bool` | Light is on |
 | `brightness` | `int \| None` | Brightness (0–255) |
 | `rgb_color` | `tuple[int, int, int] \| None` | RGB color |
+| `kelvin` | `int \| None` | Current color temperature in Kelvin |
+| `min_kelvin` | `int \| None` | Minimum supported color temperature in Kelvin |
+| `max_kelvin` | `int \| None` | Maximum supported color temperature in Kelvin |
 
 ## Methods
 
 | Method | Signature |
 |---|---|
-| `turn_on` | `async (*, brightness=None, rgb_color=None, color_temp=None, transition=None, **extra)` |
+| `turn_on` | `async (*, brightness=None, rgb_color=None, color_temp=None, kelvin=None, transition=None, **extra)` |
 | `turn_off` | `async (*, transition=None)` |
 | `toggle` | `async ()` |
 
@@ -28,3 +31,4 @@ Inherits from [`Entity`](base.md#ha_cliententityentity).
 | `@on_turn_off` | State transitions to `"off"` |
 | `@on_brightness_change` | `brightness` attribute changes |
 | `@on_color_change` | `rgb_color` attribute changes |
+| `@on_kelvin_change` | `color_temp_kelvin` attribute changes |

--- a/ha_client/domains/light.py
+++ b/ha_client/domains/light.py
@@ -32,6 +32,10 @@ class Light(Entity):
         """Register a listener for RGB color changes. Callback: ``(old, new)``."""
         return self._register_attr_listener("rgb_color", func)
 
+    def on_kelvin_change(self, func: Any) -> Any:
+        """Register a listener for color temperature (Kelvin) changes. Callback: ``(old, new)``."""
+        return self._register_attr_listener("color_temp_kelvin", func)
+
     # ------------------------------------------------------------------ state
     @property
     def is_on(self) -> bool:
@@ -42,6 +46,24 @@ class Light(Entity):
     def brightness(self) -> int | None:
         """Current brightness (0–255) or ``None`` if unsupported/unknown."""
         value = self.attributes.get("brightness")
+        return int(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def min_kelvin(self) -> int | None:
+        """Minimum supported color temperature in Kelvin, or ``None``."""
+        value = self.attributes.get("min_color_temp_kelvin")
+        return int(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def max_kelvin(self) -> int | None:
+        """Maximum supported color temperature in Kelvin, or ``None``."""
+        value = self.attributes.get("max_color_temp_kelvin")
+        return int(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def kelvin(self) -> int | None:
+        """Current color temperature in Kelvin, or ``None``."""
+        value = self.attributes.get("color_temp_kelvin")
         return int(value) if isinstance(value, (int, float)) else None
 
     @property
@@ -59,6 +81,7 @@ class Light(Entity):
         brightness: int | None = None,
         rgb_color: tuple[int, int, int] | list[int] | None = None,
         color_temp: int | None = None,
+        kelvin: int | None = None,
         transition: float | None = None,
         **extra: Any,
     ) -> None:
@@ -70,6 +93,8 @@ class Light(Entity):
             data["rgb_color"] = list(rgb_color)
         if color_temp is not None:
             data["color_temp"] = int(color_temp)
+        if kelvin is not None:
+            data["color_temp_kelvin"] = int(kelvin)
         if transition is not None:
             data["transition"] = transition
         await self.call_service("turn_on", data or None)

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -24,17 +24,21 @@ async def test_light_actions(client: HAClient, fake_ha: FakeHA) -> None:
     await light.turn_on(brightness=120, rgb_color=(1, 2, 3), color_temp=200, transition=1.5)
     await light.turn_off(transition=0.5)
     await light.toggle()
+    await light.turn_on(kelvin=4000)
     assert [c["service"] for c in fake_ha.ws_service_calls] == [
         "turn_on",
         "turn_on",
         "turn_off",
         "toggle",
+        "turn_on",
     ]
     second = fake_ha.ws_service_calls[1]["service_data"]
     assert second["brightness"] == 120
     assert second["rgb_color"] == [1, 2, 3]
     assert second["color_temp"] == 200
     assert second["transition"] == 1.5
+    kelvin_call = fake_ha.ws_service_calls[4]["service_data"]
+    assert kelvin_call["color_temp_kelvin"] == 4000
 
 
 async def test_light_state_properties() -> None:
@@ -42,15 +46,30 @@ async def test_light_state_properties() -> None:
     try:
         light = ha.light("kitchen")
         light._apply_state(
-            {"state": "on", "attributes": {"brightness": 99, "rgb_color": [1, 2, 3]}}
+            {
+                "state": "on",
+                "attributes": {
+                    "brightness": 99,
+                    "rgb_color": [1, 2, 3],
+                    "color_temp_kelvin": 4000,
+                    "min_color_temp_kelvin": 2000,
+                    "max_color_temp_kelvin": 6500,
+                },
+            }
         )
         assert light.is_on
         assert light.brightness == 99
         assert light.rgb_color == (1, 2, 3)
+        assert light.kelvin == 4000
+        assert light.min_kelvin == 2000
+        assert light.max_kelvin == 6500
         light._apply_state({"state": "off", "attributes": {}})
         assert not light.is_on
         assert light.brightness is None
         assert light.rgb_color is None
+        assert light.kelvin is None
+        assert light.min_kelvin is None
+        assert light.max_kelvin is None
     finally:
         await ha.close()
 

--- a/tests/test_granular_events.py
+++ b/tests/test_granular_events.py
@@ -318,6 +318,23 @@ async def test_light_on_color_change(client: HAClient, fake_ha: FakeHA) -> None:
     assert captured == [([0, 255, 0], [255, 0, 0])]
 
 
+async def test_light_on_kelvin_change(client: HAClient, fake_ha: FakeHA) -> None:
+    light = client.light("kitchen")
+    captured: list[tuple[Any, Any]] = []
+
+    @light.on_kelvin_change
+    def handler(old: Any, new: Any) -> None:
+        captured.append((old, new))
+
+    await fake_ha.push_state_changed(
+        "light.kitchen",
+        {"state": "on", "attributes": {"color_temp_kelvin": 5000}},
+        {"state": "on", "attributes": {"color_temp_kelvin": 3000}},
+    )
+    await asyncio.sleep(0.05)
+    assert captured == [(3000, 5000)]
+
+
 # ============================================================ Switch
 
 


### PR DESCRIPTION
## Summary

- Add `kelvin`, `min_kelvin`, and `max_kelvin` read-only properties to `Light`, mapped to HA attributes `color_temp_kelvin`, `min_color_temp_kelvin`, and `max_color_temp_kelvin`
- Add `kelvin` parameter to `turn_on()` which sends `color_temp_kelvin` in the service call
- Add `on_kelvin_change` event decorator that fires when `color_temp_kelvin` attribute changes
- Tests, docs, and README updated