### PR TITLE
Add third-party notices and acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ ruff check .
 mypy ha_client/
 ```
 
+## Acknowledgements
+
+ha-client is built on top of excellent open-source software. See
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for the full list of
+third-party dependencies and their licenses.
+
 ## License
 
 Apache 2.0 – see `LICENSE` for details.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,58 @@
+# Third-Party Notices
+
+ha-client uses the following third-party libraries. Each is listed with its
+license type and project URL.
+
+## Runtime Dependencies
+
+### aiohttp
+
+- **License:** Apache 2.0
+- **URL:** https://github.com/aio-libs/aiohttp
+- **Copyright:** Copyright aio-libs contributors
+
+### python-dotenv
+
+- **License:** BSD 3-Clause
+- **URL:** https://github.com/theskumar/python-dotenv
+- **Copyright:** Copyright (c) Saurabh Kumar
+
+## Development Dependencies
+
+### pytest
+
+- **License:** MIT
+- **URL:** https://github.com/pytest-dev/pytest
+- **Copyright:** Copyright (c) Holger Krekel and others
+
+### pytest-asyncio
+
+- **License:** Apache 2.0
+- **URL:** https://github.com/pytest-dev/pytest-asyncio
+- **Copyright:** Copyright (c) pytest-asyncio contributors
+
+### pytest-cov
+
+- **License:** MIT
+- **URL:** https://github.com/pytest-dev/pytest-cov
+- **Copyright:** Copyright (c) pytest-cov contributors
+
+### Ruff
+
+- **License:** MIT
+- **URL:** https://github.com/astral-sh/ruff
+- **Copyright:** Copyright (c) Charlie Marsh
+
+### mypy
+
+- **License:** MIT
+- **URL:** https://github.com/python/mypy
+- **Copyright:** Copyright (c) Jukka Lehtosalo and contributors
+
+## Build System
+
+### Hatchling
+
+- **License:** MIT
+- **URL:** https://github.com/pypa/hatch
+- **Copyright:** Copyright (c) Ofek Lev


### PR DESCRIPTION
## Summary
- Add `THIRD_PARTY_NOTICES.md` listing all runtime, dev, and build dependencies with their licenses and project URLs
- Add an Acknowledgements section to `README.md` linking to the notices file