### PR TITLE
[codex] Add reusable CI type-check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,15 @@ jobs:
       python-version: ${{ vars.CI_PYTHON_VERSION || '3.11' }}
       install-spec: ${{ vars.CI_PYTHON_INSTALL_SPEC || '.[dev]' }}
 
+  py-typecheck:
+    name: Python Type Check
+    if: needs.detect-stack.outputs.has-python == 'true'
+    needs: [detect-stack]
+    uses: ./.github/workflows/python-typecheck.yml
+    with:
+      python-version: ${{ vars.CI_PYTHON_VERSION || '3.11' }}
+      install-spec: ${{ vars.CI_PYTHON_INSTALL_SPEC || '.[dev]' }}
+
   py-test:
     name: Python Test
     if: needs.detect-stack.outputs.has-python == 'true'
@@ -82,17 +91,18 @@ jobs:
   quality-gate:
     name: Quality gate
     if: always()
-    needs: [detect-stack, py-lint, py-build, py-test, secrets-scan]
+    needs: [detect-stack, py-lint, py-build, py-typecheck, py-test, secrets-scan]
     runs-on: ubuntu-latest
     steps:
       - name: Check required job results
         env:
           PY_LINT: ${{ needs.py-lint.result }}
           PY_BUILD: ${{ needs.py-build.result }}
+          PY_TYPECHECK: ${{ needs.py-typecheck.result }}
           PY_TEST: ${{ needs.py-test.result }}
           SECRETS_SCAN: ${{ needs.secrets-scan.result }}
         run: |
-          results=("$PY_LINT" "$PY_BUILD" "$PY_TEST" "$SECRETS_SCAN")
+          results=("$PY_LINT" "$PY_BUILD" "$PY_TYPECHECK" "$PY_TEST" "$SECRETS_SCAN")
           for result in "${results[@]}"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               exit 1

--- a/.github/workflows/python-typecheck.yml
+++ b/.github/workflows/python-typecheck.yml
@@ -1,0 +1,38 @@
+name: Reusable Python Type Check
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version for type-checking.
+        required: false
+        type: string
+        default: "3.12"
+      install-spec:
+        description: Pip install spec, e.g. .[dev]
+        required: false
+        type: string
+        default: ".[dev]"
+
+jobs:
+  mypy:
+    name: Mypy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "${{ inputs.install-spec }}"
+
+      - name: Run mypy
+        run: python -m mypy src/haclient/


### PR DESCRIPTION
## What changed
- added a reusable `python-typecheck.yml` workflow for mypy
- wired the new type-check workflow into the top-level CI workflow
- updated the quality gate so mypy failures block the pipeline

## Why
HaClient documented mypy as part of the required CI checks but the workflow configuration did not enforce it. This closes that gap and keeps the CI contract honest.

## Impact
- CI now enforces strict type-checking in addition to lint, build, tests, and secrets scanning
- the repository is closer to the same reusable-workflow structure used for DeckUI

## Validation
- reviewed workflow diffs and staged only workflow files
- ran `git diff --check`
- did not run GitHub Actions end-to-end locally
