### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report a reproducible defect in HaClient.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for confirmed defects. Reproduce the issue on current `main` first if you can.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: State the failure in one or two sentences.
+      placeholder: `MediaPlayer.favorites()` stops returning items after the first reconnect.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: HaClient Version
+      description: Package version, commit SHA, or branch name.
+      placeholder: 0.3.2 / 6b682d0 / docs/add-github-templates
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python Version
+      placeholder: 3.11.11
+    validations:
+      required: true
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant Version
+      placeholder: 2026.4.2
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Provide exact steps or a minimal script.
+      placeholder: |
+        1. Start the fake or real Home Assistant instance
+        2. Connect with `HAClient`
+        3. Call the affected API
+        4. Observe the failure
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: The client should resubscribe and continue returning favorites.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      placeholder: The call returns an empty list after reconnect.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs Or Traceback
+      description: Paste the relevant output. Trim noise.
+      render: text
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Network conditions, auth mode, integrations involved, or anything else useful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: HaClient Discussions
+    url: https://github.com/graphras-com/HaClient/discussions
+    about: Use discussions for open-ended questions that are not actionable bugs or feature proposals.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,53 @@
+name: Feature Request
+description: Propose a new capability or API change for HaClient.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Explain the problem first. If the request changes public API, describe the intended usage clearly.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What limitation are you hitting today?
+      placeholder: There is no domain helper for fan entities, so I have to use raw service calls.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: Describe the API or behavior you want.
+      placeholder: Add a `Fan` domain class with common helpers like `turn_on`, `turn_off`, and `set_percentage`.
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: Show why this matters in a real integration or application.
+      placeholder: A control surface app needs typed fan operations instead of unstructured service payloads.
+    validations:
+      required: true
+  - type: textarea
+    id: api
+    attributes:
+      label: API Sketch
+      description: Optional. Show the intended call pattern.
+      render: python
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What workarounds or alternate designs did you consider?
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: I expect this change to require tests.
+        - label: I expect this change to require documentation updates.
+        - label: I expect this change to affect the public API.

--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+## Summary
+
+Describe the defect and the fix directly.
+
+## Root Cause
+
+What was wrong, and where?
+
+## Validation
+
+- [ ] `ruff check .`
+- [ ] `mypy src/haclient/`
+- [ ] `pytest --cov=haclient --cov-report=term-missing --cov-fail-under=95`
+- [ ] Added or updated tests that fail without this change
+- [ ] Updated docs if behavior changed
+
+## Risk
+
+What could still break?

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,19 @@
+## Summary
+
+Describe the feature and the user-facing outcome.
+
+## Design
+
+Explain the API, behavior, and any compatibility impact.
+
+## Validation
+
+- [ ] `ruff check .`
+- [ ] `mypy src/haclient/`
+- [ ] `pytest --cov=haclient --cov-report=term-missing --cov-fail-under=95`
+- [ ] Added tests for the new behavior
+- [ ] Updated docs for the new behavior
+
+## Follow-Up
+
+List anything intentionally deferred.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 API reference for `haclient` — an async-first Python client for Home Assistant.
 
+## Contribution Intake
+
+GitHub issue forms are available for bug reports and feature requests, and pull requests include separate bug-fix and feature templates. Use the matching template instead of opening an unstructured report.
+
 ## Core Library
 
 - [Base Library](base.md) — `HAClient`, `SyncHAClient`, `RestClient`, `WebSocketClient`, `Entity`, `EntityRegistry`, exceptions


### PR DESCRIPTION
## Summary
- add bug and feature issue forms
- add separate bug and feature pull request templates
- document the new structured contribution intake in docs/README.md
- disable blank issues in favor of structured intake

## Validation
- .venv/bin/ruff check .
- .venv/bin/mypy src/haclient/
- .venv/bin/pytest --cov=haclient --cov-report=term-missing --cov-fail-under=95