### PR TITLE
chore: pre-release codebase cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.9",
-  "python-dotenv>=1.2.2",
 ]
 
 [project.optional-dependencies]

--- a/src/haclient/domains/light.py
+++ b/src/haclient/domains/light.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any  # noqa: F401 – used in type hints below
+from typing import Any
 
 from ..entity import Entity
 

--- a/src/haclient/websocket.py
+++ b/src/haclient/websocket.py
@@ -84,7 +84,6 @@ class WebSocketClient:
         self._subscriptions: dict[int, EventHandler] = {}
         # event_type -> (subscription_id, handler) - used for resubscribe
         self._event_subs: dict[str, tuple[int, EventHandler]] = {}
-        self._trigger_subs: dict[int, dict[str, Any]] = {}
 
         self._reader_task: asyncio.Task[None] | None = None
         self._keepalive_task: asyncio.Task[None] | None = None


### PR DESCRIPTION
## Summary
- **Remove unused `python-dotenv` dependency** from runtime `dependencies` — it is only used in `examples/`, not by the library itself. Keeps the install footprint minimal.
- **Remove dead `_trigger_subs` dict** from `WebSocketClient` — declared but never read or written to anywhere in the codebase.
- **Clean misleading `noqa: F401` comment** on `light.py` import — `Any` is actively used in type hints; the suppression comment was incorrect.

## Audit notes
The codebase is remarkably clean for a pre-v1.0 project. No legacy shims, no backward-compat layers, no commented-out code, no duplicate implementations, and no abandoned features were found. Architecture is coherent with clear module responsibilities.

### Items reviewed and found clean
- All imports used across all modules
- No unreachable code paths
- No duplicate logic across domains
- Exception hierarchy is minimal and complete
- Registry methods (`require`, `unregister`, `in_domain`, `clear`) all have test coverage
- `on_disconnect`, `remove_listener`, `remove_granular_listener` all exercised in tests
- CI workflows, config, and tooling are consistent

### Manual review suggestions before release
- `TimeoutError` intentionally shadows the builtin (`# noqa: A001`) — acceptable design choice but worth documenting in the exceptions module docstring
- `examples/*.py` still import `python-dotenv` — consider adding it to an `[project.optional-dependencies] examples` group or documenting it as a user-installed dependency