### PR TITLE
Add PEP 257 docstrings and remove all comments

### DIFF
--- a/examples/events.py
+++ b/examples/events.py
@@ -27,7 +27,6 @@ async def main() -> None:
             state = new.get("state") if new else "unknown"
             print(f"Door is now {state}")
 
-        # Sit in an infinite loop so events keep arriving.
         print("Listening for events. Ctrl+C to quit.")
         while True:
             await asyncio.sleep(60)

--- a/examples/favorites.py
+++ b/examples/favorites.py
@@ -21,11 +21,6 @@ async def main() -> None:
         favs = await player.favorites()
         for fav in favs:
             print(fav)
-            # print(f"  {fav.media_content_type}: {fav.title}")
-
-        # if favs:
-        #    print(f"Playing: {favs[0].title}")
-        #    #await favs[0].play()
 
 
 if __name__ == "__main__":

--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -114,7 +114,6 @@ class HAClient:
         self._state_sub_id: int | None = None
         self._connected = False
 
-    # -------------------------------------------------- async context manager
     async def __aenter__(self) -> HAClient:
         await self.connect()
         return self
@@ -127,7 +126,6 @@ class HAClient:
     ) -> None:
         await self.close()
 
-    # ------------------------------------------------------- lifecycle
     @property
     def loop(self) -> asyncio.AbstractEventLoop | None:
         """Return the event loop the client is bound to (if running)."""
@@ -141,7 +139,6 @@ class HAClient:
         if self._connected:
             return
         await self.ws.connect()
-        # Seed entity states from REST so attribute access works immediately.
         try:
             states = await self.rest.get_states()
         except HAClientError as err:
@@ -154,7 +151,6 @@ class HAClient:
             entity = self.registry.get(eid)
             if entity is not None:
                 entity._apply_state(state)  # noqa: SLF001
-        # Subscribe to state_changed events so registered entities stay fresh.
         self._state_sub_id = await self.ws.subscribe_events(
             self._on_state_changed_event, "state_changed"
         )
@@ -166,8 +162,8 @@ class HAClient:
         await self.ws.close()
         await self.rest.close()
 
-    # -------------------------------------------------------- event wiring
     def _on_state_changed_event(self, event: dict[str, Any]) -> None:
+        """Dispatch a ``state_changed`` event to the appropriate entity."""
         data = event.get("data") or {}
         eid = data.get("entity_id")
         if not isinstance(eid, str):
@@ -179,7 +175,6 @@ class HAClient:
             data.get("old_state"), data.get("new_state")
         )
 
-    # ---------------------------------------------------- service helpers
     async def call_service(
         self,
         domain: str,
@@ -201,8 +196,6 @@ class HAClient:
                 "service": service,
             }
             if data:
-                # HA expects 'target'/'service_data' separation; 'service_data'
-                # works with entity_id embedded for all domains we care about.
                 payload["service_data"] = data
             return await self.ws.send_command(payload)
         return await self.rest.call_service(domain, service, data)
@@ -214,8 +207,8 @@ class HAClient:
         for entity in list(self.registry):
             entity._apply_state(index.get(entity.entity_id))  # noqa: SLF001
 
-    # --------------------------------------------------- domain accessors
     def _get_or_create(self, domain: str, name: str, cls: type[_E]) -> _E:
+        """Return the entity for *name* in *domain*, creating it if needed."""
         entity_id = self.registry.resolve(domain, name)
         existing = self.registry.get(entity_id)
         if existing is not None:

--- a/src/haclient/domains/binary_sensor.py
+++ b/src/haclient/domains/binary_sensor.py
@@ -12,7 +12,6 @@ class BinarySensor(Entity):
 
     domain = "binary_sensor"
 
-    # --------------------------------------------------------------- events
     def on_turn_on(self, func: Any) -> Any:
         """Register a listener for when the sensor activates.
 

--- a/src/haclient/domains/climate.py
+++ b/src/haclient/domains/climate.py
@@ -12,7 +12,6 @@ class Climate(Entity):
 
     domain = "climate"
 
-    # --------------------------------------------------------------- events
     def on_hvac_mode_change(self, func: Any) -> Any:
         """Register a listener for HVAC mode changes. Callback: ``(old_mode, new_mode)``."""
         return self._register_state_value_listener(func)
@@ -25,7 +24,6 @@ class Climate(Entity):
         """Register a listener for target temperature changes. Callback: ``(old, new)``."""
         return self._register_attr_listener("temperature", func)
 
-    # ------------------------------------------------------------------ state
     @property
     def current_temperature(self) -> float | None:
         """The current measured temperature, if reported."""
@@ -49,7 +47,6 @@ class Climate(Entity):
         modes = self.attributes.get("hvac_modes")
         return list(modes) if isinstance(modes, list) else []
 
-    # ------------------------------------------------------------------ actions
     async def set_temperature(
         self,
         temperature: float,

--- a/src/haclient/domains/cover.py
+++ b/src/haclient/domains/cover.py
@@ -12,7 +12,6 @@ class Cover(Entity):
 
     domain = "cover"
 
-    # --------------------------------------------------------------- events
     def on_open(self, func: Any) -> Any:
         """Register a listener for when the cover opens. Callback: ``(old_state, new_state)``."""
         return self._register_state_transition_listener("open", func)

--- a/src/haclient/domains/light.py
+++ b/src/haclient/domains/light.py
@@ -12,7 +12,6 @@ class Light(Entity):
 
     domain = "light"
 
-    # --------------------------------------------------------------- events
     def on_turn_on(self, func: Any) -> Any:
         """Register a listener for when the light turns on. Callback: ``(old_state, new_state)``."""
         return self._register_state_transition_listener("on", func)
@@ -36,7 +35,6 @@ class Light(Entity):
         """Register a listener for color temperature (Kelvin) changes. Callback: ``(old, new)``."""
         return self._register_attr_listener("color_temp_kelvin", func)
 
-    # ------------------------------------------------------------------ state
     @property
     def is_on(self) -> bool:
         """``True`` if the light is currently on."""
@@ -74,7 +72,6 @@ class Light(Entity):
             return (int(value[0]), int(value[1]), int(value[2]))
         return None
 
-    # ------------------------------------------------------------------ actions
     async def turn_on(
         self,
         *,

--- a/src/haclient/domains/media_player.py
+++ b/src/haclient/domains/media_player.py
@@ -18,7 +18,6 @@ from ..exceptions import CommandError, HAClientError
 
 _LOGGER = logging.getLogger(__name__)
 
-# Safety cap so that misbehaving integrations cannot send us into a huge tree.
 _MAX_BROWSE_NODES = 2000
 _MAX_BROWSE_DEPTH = 6
 
@@ -146,7 +145,6 @@ class MediaPlayer(Entity):
         super().__init__(entity_id, client)
         self._media_change_listeners: list[ValueChangeHandler] = []
 
-    # --------------------------------------------------------------- events
     def on_volume_change(self, func: Any) -> Any:
         """Register a listener for volume level changes. Callback: ``(old, new)``."""
         return self._register_attr_listener("volume_level", func)
@@ -204,7 +202,6 @@ class MediaPlayer(Entity):
             return
         super().remove_granular_listener(func)
 
-    # ------------------------------------------------------------------ state
     @property
     def is_playing(self) -> bool:
         """``True`` if the media player is currently playing."""
@@ -231,7 +228,6 @@ class MediaPlayer(Entity):
         """Structured snapshot of the currently playing media."""
         return _now_playing_from_attrs(self.attributes)
 
-    # ------------------------------------------------------------- playback
     async def play(self) -> None:
         """Resume / start playback."""
         await self.call_service("media_play")
@@ -292,7 +288,6 @@ class MediaPlayer(Entity):
         }
         await self.call_service("play_media", data)
 
-    # ------------------------------------------------------------- favorites
     async def browse_media(
         self,
         media_content_type: str | None = None,
@@ -352,10 +347,6 @@ class MediaPlayer(Entity):
         seen: set[tuple[str, str]] = set()
         node_count = 0
 
-        # The "root" node for a favorites browse is typically a generic
-        # "Favorites" directory; its title is not useful as a category. We
-        # therefore only start inheriting the parent's title as the category
-        # once we are at least one level deep.
         async def walk(node: dict[str, Any], depth: int, category: str | None) -> None:
             nonlocal node_count
             if node_count >= max_nodes:
@@ -412,10 +403,6 @@ class MediaPlayer(Entity):
                         continue
                     except asyncio.CancelledError:
                         raise
-                    # Pass the child's title as category for its descendants.
-                    # At depth 0 the child *is* a top-level folder like
-                    # "Radio" / "Albums" / "Playlists" and its title becomes
-                    # the category for everything underneath.
                     child_category = str(title) if title else category
                     await walk(sub, depth + 1, child_category)
 

--- a/src/haclient/domains/sensor.py
+++ b/src/haclient/domains/sensor.py
@@ -12,7 +12,6 @@ class Sensor(Entity):
 
     domain = "sensor"
 
-    # --------------------------------------------------------------- events
     def on_value_change(self, func: Any) -> Any:
         """Register a listener for sensor value changes. Callback: ``(old_state, new_state)``."""
         return self._register_state_value_listener(func)

--- a/src/haclient/domains/switch.py
+++ b/src/haclient/domains/switch.py
@@ -12,7 +12,6 @@ class Switch(Entity):
 
     domain = "switch"
 
-    # --------------------------------------------------------------- events
     def on_turn_on(self, func: Any) -> Any:
         """Register a listener for when the switch turns on.
 

--- a/src/haclient/entity.py
+++ b/src/haclient/entity.py
@@ -25,7 +25,7 @@ V = TypeVar("V", bound=ValueChangeHandler)
 
 
 class Entity:
-    """Represents a single Home Assistant entity.
+    """Represent a single Home Assistant entity.
 
     Subclasses map to specific domains (``media_player``, ``light``, ...) and
     should override :attr:`domain` and add domain-specific methods.
@@ -35,7 +35,7 @@ class Entity:
     client receives ``state_changed`` events for this entity.
     """
 
-    domain: str = ""  # overridden by subclasses
+    domain: str = ""
 
     def __init__(self, entity_id: str, client: HAClient) -> None:
         if "." not in entity_id:
@@ -52,7 +52,6 @@ class Entity:
         self._state_value_listeners: list[ValueChangeHandler] = []
         client.registry.register(self)
 
-    # --------------------------------------------------------- state plumbing
     def _apply_state(self, state_obj: dict[str, Any] | None) -> None:
         """Apply a raw state object (as returned by Home Assistant)."""
         if state_obj is None:
@@ -68,12 +67,10 @@ class Entity:
         old_state: dict[str, Any] | None,
         new_state: dict[str, Any] | None,
     ) -> None:
-        """Internal: update local state and dispatch listeners."""
+        """Update local state and dispatch listeners."""
         self._apply_state(new_state)
-        # Generic state_change listeners
         for listener in list(self._listeners):
             self._schedule(listener, old_state, new_state)
-        # Higher-level event dispatch
         self._dispatch_granular_events(old_state, new_state)
 
     def _dispatch_granular_events(
@@ -87,17 +84,14 @@ class Entity:
         old_attrs = (old_state or {}).get("attributes") or {}
         new_attrs = (new_state or {}).get("attributes") or {}
 
-        # State value change listeners (fire when state string changes)
         if old_state_str != new_state_str:
             for listener in list(self._state_value_listeners):
                 self._schedule_value(listener, old_state_str, new_state_str)
 
-        # State transition listeners (fire when state transitions TO a value)
         if old_state_str != new_state_str and new_state_str is not None:
             for listener in list(self._state_transition_listeners.get(new_state_str, [])):
                 self._schedule_value(listener, old_state_str, new_state_str)
 
-        # Attribute listeners
         for attr_key, listeners in self._attr_listeners.items():
             old_val = old_attrs.get(attr_key)
             new_val = new_attrs.get(attr_key)
@@ -111,6 +105,7 @@ class Entity:
         old_state: dict[str, Any] | None,
         new_state: dict[str, Any] | None,
     ) -> None:
+        """Invoke a state-change handler, scheduling coroutines on the loop."""
         try:
             result = handler(old_state, new_state)
         except Exception:  # pragma: no cover - defensive
@@ -144,7 +139,6 @@ class Entity:
             else:  # pragma: no cover - only reached without running loop
                 asyncio.ensure_future(awaitable)
 
-    # ------------------------------------------------- granular event helpers
     def _register_attr_listener(self, attr_key: str, func: V) -> V:
         """Register a listener for changes to a specific attribute.
 
@@ -174,21 +168,17 @@ class Entity:
 
     def remove_granular_listener(self, func: ValueChangeHandler) -> None:
         """Remove a previously registered granular (attribute/state) listener."""
-        # Search attr listeners
         for listeners in self._attr_listeners.values():
             with contextlib.suppress(ValueError):
                 listeners.remove(func)
                 return
-        # Search state transition listeners
         for listeners in self._state_transition_listeners.values():
             with contextlib.suppress(ValueError):
                 listeners.remove(func)
                 return
-        # Search state value listeners
         with contextlib.suppress(ValueError):
             self._state_value_listeners.remove(func)
 
-    # ------------------------------------------------------------- decorators
     def on_state_change(self, func: F) -> F:
         """Register ``func`` as a listener for state changes on this entity.
 
@@ -205,7 +195,6 @@ class Entity:
         with contextlib.suppress(ValueError):
             self._listeners.remove(func)
 
-    # ----------------------------------------------------------- convenience
     @property
     def available(self) -> bool:
         """Return ``True`` if the entity is currently available."""

--- a/src/haclient/exceptions.py
+++ b/src/haclient/exceptions.py
@@ -28,7 +28,7 @@ class CommandError(HAClientError):
         self.message = message
 
 
-class TimeoutError(HAClientError):  # noqa: A001 - intentional shadow of builtin
+class TimeoutError(HAClientError):  # noqa: A001
     """Raised when a request to Home Assistant does not complete in time."""
 
 

--- a/src/haclient/registry.py
+++ b/src/haclient/registry.py
@@ -23,7 +23,6 @@ class EntityRegistry:
     def __init__(self) -> None:
         self._entities: dict[str, Entity] = {}
 
-    # ------------------------------------------------------------------ core
     def register(self, entity: Entity) -> None:
         """Register ``entity`` (overwriting any existing entry)."""
         self._entities[entity.entity_id] = entity
@@ -56,7 +55,6 @@ class EntityRegistry:
         """Remove all registered entities."""
         self._entities.clear()
 
-    # -------------------------------------------------------------- lookup
     def resolve(self, domain: str, name: str) -> str:
         """Resolve a short name to a full ``entity_id`` within ``domain``.
 

--- a/src/haclient/rest.py
+++ b/src/haclient/rest.py
@@ -43,8 +43,8 @@ class RestClient:
         self._session = session
         self._owns_session = session is None
 
-    # ------------------------------------------------------------- lifecycle
     async def _ensure_session(self) -> aiohttp.ClientSession:
+        """Return the current session, creating one if necessary."""
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
             self._owns_session = True
@@ -55,15 +55,16 @@ class RestClient:
         if self._owns_session and self._session is not None and not self._session.closed:
             await self._session.close()
 
-    # --------------------------------------------------------------- helpers
     @property
     def _headers(self) -> dict[str, str]:
+        """Return the authorization and content-type headers."""
         return {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
         }
 
     def _url(self, path: str) -> str:
+        """Build a full URL from a relative API path."""
         if not path.startswith("/"):
             path = "/" + path
         return f"{self._base_url}{path}"
@@ -75,6 +76,7 @@ class RestClient:
         *,
         json: Any | None = None,
     ) -> Any:
+        """Perform an HTTP request and return the parsed response."""
         session = await self._ensure_session()
         url = self._url(path)
         try:
@@ -99,7 +101,6 @@ class RestClient:
         except aiohttp.ClientError as err:
             raise HAClientError(f"HTTP request failed: {err}") from err
 
-    # ---------------------------------------------------------------- public
     async def ping(self) -> bool:
         """Return ``True`` if the Home Assistant API is reachable."""
         await self._request("GET", "/api/")
@@ -117,7 +118,6 @@ class RestClient:
         try:
             data = await self._request("GET", f"/api/states/{entity_id}")
         except HAClientError as err:
-            # HA returns 404 for unknown entities
             if "HTTP 404" in str(err):
                 return None
             raise

--- a/src/haclient/sync.py
+++ b/src/haclient/sync.py
@@ -42,6 +42,7 @@ class _LoopThread:
         self._started.wait()
 
     def _run(self) -> None:
+        """Execute the event loop until stopped."""
         asyncio.set_event_loop(self.loop)
         self._started.set()
         try:
@@ -57,18 +58,21 @@ class _LoopThread:
                 self.loop.close()
 
     def submit(self, coro: Awaitable[T], *, timeout: float | None = None) -> T:
+        """Submit an awaitable to the background loop and block for the result."""
         if not inspect.isawaitable(coro):  # pragma: no cover - defensive
             raise TypeError("submit() expects an awaitable")
         future = asyncio.run_coroutine_threadsafe(_ensure_coro(coro), self.loop)
         return future.result(timeout=timeout)
 
     def stop(self) -> None:
+        """Stop the event loop and join the background thread."""
         if not self.loop.is_closed():
             self.loop.call_soon_threadsafe(self.loop.stop)
         self._thread.join(timeout=5.0)
 
 
 async def _ensure_coro(awaitable: Awaitable[T]) -> T:
+    """Wrap an arbitrary awaitable into a proper coroutine."""
     return await awaitable
 
 
@@ -120,7 +124,6 @@ class SyncHAClient:
         """Return the underlying :class:`HAClient` instance."""
         return self._client
 
-    # ----------------------------------------------------- connection lifecycle
     def connect(self) -> None:
         """Connect the underlying client."""
         self._loop_thread.submit(self._client.connect())
@@ -139,7 +142,6 @@ class SyncHAClient:
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         self.close()
 
-    # ------------------------------------------------------- service helpers
     def call_service(self, domain: str, service: str, data: dict[str, Any] | None = None) -> Any:
         """Invoke a Home Assistant service synchronously."""
         return self._loop_thread.submit(self._client.call_service(domain, service, data))
@@ -148,7 +150,6 @@ class SyncHAClient:
         """Refresh all registered entities synchronously."""
         self._loop_thread.submit(self._client.refresh_all())
 
-    # ---------------------------------------------------- domain accessors
     def media_player(self, name: str) -> Any:
         """Return a sync proxy wrapping the async :class:`MediaPlayer`."""
         return _SyncProxy(self._client.media_player(name), self._loop_thread)

--- a/src/haclient/websocket.py
+++ b/src/haclient/websocket.py
@@ -80,9 +80,7 @@ class WebSocketClient:
         self._message_id = 0
         self._pending: dict[int, asyncio.Future[Any]] = {}
         self._pong_waiters: dict[int, asyncio.Future[Any]] = {}
-        # id -> handler for subscription/event messages
         self._subscriptions: dict[int, EventHandler] = {}
-        # event_type -> (subscription_id, handler) - used for resubscribe
         self._event_subs: dict[str, tuple[int, EventHandler]] = {}
 
         self._reader_task: asyncio.Task[None] | None = None
@@ -91,13 +89,11 @@ class WebSocketClient:
         self._connected = asyncio.Event()
         self._disconnect_listeners: list[Callable[[], Awaitable[None] | None]] = []
 
-    # ---------------------------------------------------------- properties
     @property
     def connected(self) -> bool:
         """Return ``True`` while the underlying socket is open."""
         return self._ws is not None and not self._ws.closed
 
-    # ------------------------------------------------------------- lifecycle
     async def connect(self) -> None:
         """Establish the WebSocket connection and authenticate."""
         if self.connected:
@@ -111,12 +107,14 @@ class WebSocketClient:
             )
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
+        """Return the current session, creating one if necessary."""
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
             self._owns_session = True
         return self._session
 
     async def _do_connect(self) -> None:
+        """Open the WebSocket and perform the authentication handshake."""
         session = await self._ensure_session()
         try:
             self._ws = await session.ws_connect(
@@ -128,7 +126,6 @@ class WebSocketClient:
         except aiohttp.ClientError as err:
             raise HAClientError(f"Failed to connect to {self._url}: {err}") from err
 
-        # Auth handshake: auth_required -> auth -> auth_ok | auth_invalid
         msg = await self._recv_json()
         if msg.get("type") != "auth_required":
             raise AuthenticationError(f"Expected auth_required, got {msg.get('type')!r}")
@@ -160,7 +157,6 @@ class WebSocketClient:
             except (TimeoutError, asyncio.CancelledError, Exception):  # noqa: BLE001
                 self._reader_task.cancel()
             self._reader_task = None
-        # Fail any pending requests so callers don't hang forever.
         for fut in self._pending.values():
             if not fut.done():
                 fut.set_exception(ConnectionClosedError("WebSocket closed"))
@@ -179,12 +175,13 @@ class WebSocketClient:
         self._disconnect_listeners.append(handler)
         return handler
 
-    # ------------------------------------------------------- send / receive
     def _next_id(self) -> int:
+        """Return the next monotonically-increasing message id."""
         self._message_id += 1
         return self._message_id
 
     async def _recv_json(self) -> dict[str, Any]:
+        """Read a single JSON message from the WebSocket."""
         assert self._ws is not None
         msg = await self._ws.receive()
         if msg.type == aiohttp.WSMsgType.TEXT:
@@ -235,7 +232,6 @@ class WebSocketClient:
             self._pending.pop(cmd_id, None)
         return result
 
-    # ---------------------------------------------------------- subscriptions
     async def subscribe_events(
         self,
         handler: EventHandler,
@@ -275,8 +271,8 @@ class WebSocketClient:
             if sid == subscription_id:
                 self._event_subs.pop(k, None)
 
-    # ------------------------------------------------------------- reader loop
     async def _reader_loop(self) -> None:
+        """Consume incoming WebSocket messages until the socket closes."""
         assert self._ws is not None
         try:
             while not self._closing:
@@ -306,7 +302,6 @@ class WebSocketClient:
                     break
         finally:
             self._connected.clear()
-            # Fail any pending requests so callers unblock.
             for fut in list(self._pending.values()):
                 if not fut.done():
                     fut.set_exception(ConnectionClosedError("WebSocket closed"))
@@ -320,6 +315,7 @@ class WebSocketClient:
                 asyncio.create_task(self._reconnect_loop(), name="ha-ws-reconnect")
 
     async def _notify_disconnect(self) -> None:
+        """Invoke all registered disconnect listeners."""
         for listener in list(self._disconnect_listeners):
             try:
                 result = listener()
@@ -329,6 +325,7 @@ class WebSocketClient:
                 _LOGGER.exception("Disconnect listener raised")
 
     async def _dispatch(self, msg: dict[str, Any]) -> None:
+        """Route an incoming message to the appropriate handler or future."""
         mtype = msg.get("type")
         mid = msg.get("id")
         if mtype == "result":
@@ -358,10 +355,10 @@ class WebSocketClient:
                 if pong_fut is not None and not pong_fut.done():
                     pong_fut.set_result(msg)
             return
-        # Unhandled – log at debug for visibility in tests.
         _LOGGER.debug("Unhandled WS message: %s", mtype)
 
     async def _invoke_handler(self, handler: EventHandler, event: dict[str, Any]) -> None:
+        """Call an event handler, awaiting it if it returns a coroutine."""
         try:
             result = handler(event)
             if asyncio.iscoroutine(result):
@@ -369,8 +366,8 @@ class WebSocketClient:
         except Exception:  # pragma: no cover - defensive
             _LOGGER.exception("Event handler raised")
 
-    # ---------------------------------------------------------- reconnect
     async def _reconnect_loop(self) -> None:
+        """Attempt to re-establish the connection with exponential back-off."""
         delay = 1.0
         attempt = 0
         while not self._closing:
@@ -384,13 +381,11 @@ class WebSocketClient:
                 delay = min(delay * 2, 60.0)
                 continue
 
-            # Restart background loops.
             self._reader_task = asyncio.create_task(self._reader_loop(), name="ha-ws-reader")
             if self._ping_interval > 0:
                 self._keepalive_task = asyncio.create_task(
                     self._keepalive_loop(), name="ha-ws-keepalive"
                 )
-            # Re-subscribe prior event subscriptions.
             for event_type, (_old_id, handler) in list(self._event_subs.items()):
                 try:
                     await self.subscribe_events(handler, event_type)
@@ -398,7 +393,6 @@ class WebSocketClient:
                     _LOGGER.warning("Failed to resubscribe to %s: %s", event_type, err)
             return
 
-    # ---------------------------------------------------------- keepalive
     async def ping(self, *, timeout: float | None = None) -> None:
         """Send a ``ping`` frame and wait for the matching ``pong``.
 
@@ -422,6 +416,7 @@ class WebSocketClient:
             self._pong_waiters.pop(cmd_id, None)
 
     async def _keepalive_loop(self) -> None:
+        """Periodically ping the server and force a reconnect on timeout."""
         try:
             while self.connected and not self._closing:
                 await asyncio.sleep(self._ping_interval)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ async def client(fake_ha: FakeHA) -> AsyncIterator[HAClient]:
     ha = HAClient(
         fake_ha.base_url,
         token=fake_ha.token,
-        ping_interval=0,  # disable keepalive for deterministic tests
+        ping_interval=0,
         request_timeout=5.0,
     )
     await ha.connect()

--- a/tests/fake_ha.py
+++ b/tests/fake_ha.py
@@ -55,7 +55,6 @@ class FakeHA:
         self.reject_auth: bool = False
         self.drop_on_command: str | None = None
 
-
     async def start(self) -> str:
         self._runner = web.AppRunner(self._app)
         await self._runner.setup()

--- a/tests/fake_ha.py
+++ b/tests/fake_ha.py
@@ -45,36 +45,28 @@ class FakeHA:
         self._site: web.TCPSite | None = None
         self.port: int = 0
 
-        # Tracked per-test.
         self.rest_service_calls: list[tuple[str, str, dict[str, Any]]] = []
         self.ws_service_calls: list[dict[str, Any]] = []
         self.connections: list[web.WebSocketResponse] = []
-        # event_type -> list of subscription ids that subscribed to it
         self.subscriptions: dict[str, list[int]] = {}
 
-        # Custom command handler – keys are ``type`` strings, values are
-        # functions (server, ws, msg) -> awaitable. When set, overrides the
-        # built-in handler for that type.
         self.handlers: dict[str, CommandHandler] = {}
 
-        # Control knobs for tests.
         self.reject_auth: bool = False
-        self.drop_on_command: str | None = None  # close WS when this command arrives
+        self.drop_on_command: str | None = None
 
-    # --------------------------------------------------------------- lifecycle
+
     async def start(self) -> str:
         self._runner = web.AppRunner(self._app)
         await self._runner.setup()
         self._site = web.TCPSite(self._runner, "127.0.0.1", 0)
         await self._site.start()
-        # Figure out the port that was assigned.
         server = self._site._server  # type: ignore[attr-defined]
         assert server is not None
         self.port = server.sockets[0].getsockname()[1]
         return f"http://127.0.0.1:{self.port}"
 
     async def stop(self) -> None:
-        # Close any lingering WS sessions first.
         for ws in list(self.connections):
             if not ws.closed:
                 await ws.close()
@@ -91,7 +83,6 @@ class FakeHA:
     def ws_url(self) -> str:
         return f"ws://127.0.0.1:{self.port}/api/websocket"
 
-    # ------------------------------------------------------------------ REST
     def _check_token(self, request: web.Request) -> web.Response | None:
         if not self.require_auth:
             return None
@@ -135,13 +126,11 @@ class FakeHA:
         self.rest_service_calls.append((domain, service, payload))
         return web.json_response([])
 
-    # -------------------------------------------------------------- WebSocket
     async def _handle_ws(self, request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         self.connections.append(ws)
         try:
-            # auth handshake
             await ws.send_json({"type": "auth_required", "ha_version": "2024.1.0"})
             msg = await ws.receive()
             if msg.type != WSMsgType.TEXT:
@@ -168,12 +157,10 @@ class FakeHA:
         mtype = msg.get("type", "")
         mid = msg.get("id")
 
-        # Allow tests to drop the connection mid-flight.
         if self.drop_on_command == mtype:
             await ws.close()
             return
 
-        # Custom override first.
         handler = self.handlers.get(mtype)
         if handler is not None:
             await handler(self, ws, msg)
@@ -205,7 +192,6 @@ class FakeHA:
             await ws.send_json({"id": mid, "type": "result", "success": True, "result": {}})
             return
 
-        # Unknown command – send an error result so callers see a failure.
         await ws.send_json(
             {
                 "id": mid,
@@ -215,7 +201,6 @@ class FakeHA:
             }
         )
 
-    # ------------------------------------------------------- test helpers
     async def push_event(self, event_type: str, event: dict[str, Any]) -> None:
         """Push an ``event`` to every WS currently subscribed to ``event_type``.
 
@@ -233,7 +218,6 @@ class FakeHA:
                         "event": {"event_type": event_type, **event},
                     }
                 )
-        # Small yield so receivers can process.
         await asyncio.sleep(0)
 
     async def push_state_changed(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,10 +27,7 @@ async def test_connect_primes_state(fake_ha: FakeHA) -> None:
     ha = HAClient(fake_ha.base_url, fake_ha.token, ping_interval=0)
     try:
         await ha.connect()
-        # Accessor triggers registration; state should populate immediately via refresh.
         light = ha.light("kitchen")
-        # After entity creation, manually refresh to pick up state since connect()
-        # only primes *already registered* entities.
         await light.async_refresh()
         assert light.is_on
         assert light.brightness == 150
@@ -59,7 +56,6 @@ async def test_state_changed_dispatches_to_entity(client: HAClient, fake_ha: Fak
         "light.kitchen",
         {"state": "on", "attributes": {"brightness": 180}},
     )
-    # Allow event dispatch.
     for _ in range(20):
         await asyncio.sleep(0.02)
         if light.is_on:
@@ -72,7 +68,6 @@ async def test_domain_accessor_reuse(client: HAClient) -> None:
     a = client.media_player("livingroom")
     b = client.media_player("livingroom")
     assert a is b
-    # Full entity_id works too.
     c = client.media_player("media_player.livingroom")
     assert c is a
 
@@ -80,7 +75,6 @@ async def test_domain_accessor_reuse(client: HAClient) -> None:
 async def test_domain_accessor_type_conflict(client: HAClient) -> None:
     client.light("kitchen")
     with pytest.raises(HAClientError):
-        # Already registered as Light; requesting Switch with same entity id fails.
         from haclient import Switch
 
         client._get_or_create("light", "kitchen", Switch)
@@ -102,7 +96,6 @@ async def test_refresh_all(client: HAClient, fake_ha: FakeHA) -> None:
 
 async def test_refresh_all_marks_missing_unavailable(client: HAClient, fake_ha: FakeHA) -> None:
     light = client.light("kitchen")
-    # states is empty → entity should become unavailable
     await client.refresh_all()
     assert not light.available
     assert light.state == "unavailable"
@@ -117,7 +110,6 @@ async def test_context_manager(fake_ha: FakeHA) -> None:
 async def test_call_service_via_rest_fallback(fake_ha: FakeHA) -> None:
     """If WS isn't connected, fall back to REST."""
     ha = HAClient(fake_ha.base_url, fake_ha.token, ping_interval=0)
-    # Do NOT connect – WS is not up, so a call_service(use_websocket=False) routes via REST.
     try:
         await ha.call_service("switch", "toggle", {"entity_id": "switch.x"}, use_websocket=False)
     finally:
@@ -130,21 +122,19 @@ async def test_invalid_entity_id_direct_construction() -> None:
     from haclient import Light
 
     with pytest.raises(ValueError):
-        Light("kitchen", ha)  # missing domain
+        Light("kitchen", ha)
 
 
 async def test_double_connect_is_noop(client: HAClient) -> None:
-    await client.connect()  # already connected, should return immediately
+    await client.connect()
 
 
 def test_loop_property_without_running_loop() -> None:
     ha = HAClient("http://x", "t")
-    # Calling from a synchronous context: no running loop → None.
     assert ha.loop is None
 
 
 async def test_state_changed_event_missing_entity_id(client: HAClient) -> None:
-    # Sends a state_changed with malformed data – must be a no-op.
     client._on_state_changed_event({"data": {"entity_id": 42}})
     client._on_state_changed_event({})
 
@@ -154,7 +144,6 @@ async def test_connect_primes_already_registered_entity(fake_ha: FakeHA) -> None
         {"entity_id": "light.kitchen", "state": "on", "attributes": {"brightness": 90}},
     ]
     ha = HAClient(fake_ha.base_url, fake_ha.token, ping_interval=0)
-    # Pre-register the light before connect.
     from haclient import Light
 
     light = Light("light.kitchen", ha)
@@ -170,7 +159,7 @@ async def test_initial_state_fetch_includes_non_string_entity_id(
     fake_ha: FakeHA,
 ) -> None:
     fake_ha.states = [
-        {"entity_id": 123, "state": "on", "attributes": {}},  # malformed
+        {"entity_id": 123, "state": "on", "attributes": {}},
         {"entity_id": "light.kitchen", "state": "on", "attributes": {}},
     ]
     ha = HAClient(fake_ha.base_url, fake_ha.token, ping_interval=0)
@@ -181,12 +170,8 @@ async def test_initial_state_fetch_includes_non_string_entity_id(
 
 
 async def test_initial_state_fetch_failure_is_logged(fake_ha: FakeHA, caplog: Any) -> None:
-    # Break REST auth so initial /api/states fails; connect should still succeed.
     ha = HAClient(fake_ha.base_url, "wrong-token", ping_interval=0)
-    # But WS auth needs the real token, so use a different strategy: point REST at
-    # a closed port while leaving WS on the real server.
     ha.rest._token = "still-wrong"  # noqa: SLF001
-    # WS token is still the real one so connection proceeds.
     ha._token = fake_ha.token  # noqa: SLF001
     ha.ws._token = fake_ha.token  # noqa: SLF001
     try:

--- a/tests/test_entity_events.py
+++ b/tests/test_entity_events.py
@@ -68,7 +68,6 @@ async def test_remove_listener(client: HAClient, fake_ha: FakeHA) -> None:
 
     light.on_state_change(handler)
     light.remove_listener(handler)
-    # removing twice is a no-op
     light.remove_listener(handler)
     await fake_ha.push_state_changed("light.kitchen", {"state": "on", "attributes": {}})
     await asyncio.sleep(0.05)
@@ -86,6 +85,5 @@ async def test_unavailable_state(client: HAClient, fake_ha: FakeHA) -> None:
 async def test_state_change_for_unknown_entity_is_ignored(
     client: HAClient, fake_ha: FakeHA
 ) -> None:
-    # Nothing registered for switch.mystery; event dispatch must not explode.
     await fake_ha.push_state_changed("switch.mystery", {"state": "on", "attributes": {}})
     await asyncio.sleep(0.05)

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -33,8 +33,8 @@ def _make_tree() -> dict[str, Any]:
                 "media_content_type": "track",
                 "can_expand": False,
                 "can_play": True,
-        },
-        {
+            },
+            {
                 "title": "Single Track dup",
                 "media_content_id": "track://1",
                 "media_content_type": "track",

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -33,9 +33,8 @@ def _make_tree() -> dict[str, Any]:
                 "media_content_type": "track",
                 "can_expand": False,
                 "can_play": True,
-            },
-            # Duplicated child – should be de-duplicated on output.
-            {
+        },
+        {
                 "title": "Single Track dup",
                 "media_content_id": "track://1",
                 "media_content_type": "track",
@@ -63,7 +62,6 @@ def _make_subtree() -> dict[str, Any]:
             },
             {
                 "title": "BadItem",
-                # missing media_content_id → must be skipped
                 "media_content_type": "track",
                 "can_play": True,
                 "can_expand": False,
@@ -118,14 +116,11 @@ async def test_favorites_flattens_tree(client: HAClient, fake_ha: FakeHA) -> Non
     favs = await mp.favorites()
     titles = [f.title for f in favs]
     ids = [f.media_content_id for f in favs]
-    # Expected: Single Track (dedup), Playlist A, Song 1, Song 2
     assert "Single Track" in titles
     assert "Playlist A" in titles
     assert "Song 1" in titles
     assert "Song 2" in titles
-    # No duplicates
     assert len(ids) == len(set(ids))
-    # BadItem (missing content id) must be excluded.
     assert "BadItem" not in titles
 
 
@@ -134,7 +129,6 @@ async def test_favorites_item_play(client: HAClient, fake_ha: FakeHA) -> None:
     mp = client.media_player("livingroom")
     favs = await mp.favorites()
     assert favs
-    # Pick the Playlist A favorite and play it.
     playlist = next(f for f in favs if f.title == "Playlist A")
     await playlist.play()
     call = fake_ha.ws_service_calls[-1]
@@ -165,9 +159,6 @@ async def test_favorites_max_depth(client: HAClient, fake_ha: FakeHA) -> None:
     """Guard: max_depth stops recursion."""
     fake_ha.handlers["media_player/browse_media"] = _browse_handler
     mp = client.media_player("livingroom")
-    # max_depth=1 means only the top-level children are considered – we should
-    # get the Single Track but *not* Song 1 / Song 2 (those live two levels
-    # below the root).
     favs = await mp.favorites(max_depth=1)
     titles = [f.title for f in favs]
     assert "Single Track" in titles
@@ -178,8 +169,6 @@ async def test_favorites_max_nodes(client: HAClient, fake_ha: FakeHA) -> None:
     fake_ha.handlers["media_player/browse_media"] = _browse_handler
     mp = client.media_player("livingroom")
     result = await mp.favorites(max_nodes=1)
-    # With only one node visited we cannot descend; the only candidates are
-    # those discovered at the root node itself.
     assert all(isinstance(f.title, str) for f in result)
 
 
@@ -196,7 +185,6 @@ async def test_favorites_subtree_failure_is_tolerated(client: HAClient, fake_ha:
                 }
             )
         else:
-            # Every subtree browse fails.
             await ws.send_json(
                 {
                     "id": msg["id"],
@@ -210,7 +198,7 @@ async def test_favorites_subtree_failure_is_tolerated(client: HAClient, fake_ha:
     mp = client.media_player("livingroom")
     favs = await mp.favorites()
     titles = [f.title for f in favs]
-    assert "Single Track" in titles  # still collected from the root
+    assert "Single Track" in titles
     assert "Song 1" not in titles
 
 
@@ -393,5 +381,4 @@ async def test_browse_media_malformed_response(client: HAClient, fake_ha: FakeHA
 
     fake_ha.handlers["media_player/browse_media"] = bad
     mp = client.media_player("livingroom")
-    # favorites swallows HAClientError from browse_media.
     assert await mp.favorites() == []

--- a/tests/test_granular_events.py
+++ b/tests/test_granular_events.py
@@ -245,8 +245,6 @@ async def test_media_player_on_stop(client: HAClient, fake_ha: FakeHA) -> None:
     assert captured == [("playing", "idle")]
 
 
-
-
 async def test_light_on_turn_on(client: HAClient, fake_ha: FakeHA) -> None:
     light = client.light("kitchen")
     captured: list[tuple[Any, Any]] = []
@@ -332,8 +330,6 @@ async def test_light_on_kelvin_change(client: HAClient, fake_ha: FakeHA) -> None
     assert captured == [(3000, 5000)]
 
 
-
-
 async def test_switch_on_turn_on(client: HAClient, fake_ha: FakeHA) -> None:
     switch = client.switch("pump")
     captured: list[tuple[Any, Any]] = []
@@ -368,8 +364,6 @@ async def test_switch_on_turn_off(client: HAClient, fake_ha: FakeHA) -> None:
     assert captured == [("on", "off")]
 
 
-
-
 async def test_binary_sensor_on_turn_on(client: HAClient, fake_ha: FakeHA) -> None:
     sensor = client.binary_sensor("motion")
     captured: list[tuple[Any, Any]] = []
@@ -402,8 +396,6 @@ async def test_binary_sensor_on_turn_off(client: HAClient, fake_ha: FakeHA) -> N
     )
     await asyncio.sleep(0.05)
     assert captured == [("on", "off")]
-
-
 
 
 async def test_cover_on_open(client: HAClient, fake_ha: FakeHA) -> None:
@@ -455,8 +447,6 @@ async def test_cover_on_position_change(client: HAClient, fake_ha: FakeHA) -> No
     )
     await asyncio.sleep(0.05)
     assert captured == [(50, 75)]
-
-
 
 
 async def test_climate_on_hvac_mode_change(client: HAClient, fake_ha: FakeHA) -> None:
@@ -527,8 +517,6 @@ async def test_climate_on_target_temperature_change(client: HAClient, fake_ha: F
     assert captured == [(22.0, 24.0)]
 
 
-
-
 async def test_sensor_on_value_change(client: HAClient, fake_ha: FakeHA) -> None:
     sensor = client.sensor("temperature")
     captured: list[tuple[Any, Any]] = []
@@ -563,8 +551,6 @@ async def test_sensor_on_value_change_not_fired_when_same(
     )
     await asyncio.sleep(0.05)
     assert captured == []
-
-
 
 
 async def test_async_granular_handler(client: HAClient, fake_ha: FakeHA) -> None:

--- a/tests/test_granular_events.py
+++ b/tests/test_granular_events.py
@@ -10,8 +10,6 @@ from haclient.domains.media_player import NowPlaying
 
 from .fake_ha import FakeHA
 
-# ============================================================ MediaPlayer
-
 
 async def test_media_player_on_volume_change(client: HAClient, fake_ha: FakeHA) -> None:
     player = client.media_player("living_room")
@@ -247,7 +245,6 @@ async def test_media_player_on_stop(client: HAClient, fake_ha: FakeHA) -> None:
     assert captured == [("playing", "idle")]
 
 
-# ============================================================ Light
 
 
 async def test_light_on_turn_on(client: HAClient, fake_ha: FakeHA) -> None:
@@ -335,7 +332,6 @@ async def test_light_on_kelvin_change(client: HAClient, fake_ha: FakeHA) -> None
     assert captured == [(3000, 5000)]
 
 
-# ============================================================ Switch
 
 
 async def test_switch_on_turn_on(client: HAClient, fake_ha: FakeHA) -> None:
@@ -372,7 +368,6 @@ async def test_switch_on_turn_off(client: HAClient, fake_ha: FakeHA) -> None:
     assert captured == [("on", "off")]
 
 
-# ============================================================ BinarySensor
 
 
 async def test_binary_sensor_on_turn_on(client: HAClient, fake_ha: FakeHA) -> None:
@@ -409,7 +404,6 @@ async def test_binary_sensor_on_turn_off(client: HAClient, fake_ha: FakeHA) -> N
     assert captured == [("on", "off")]
 
 
-# ============================================================ Cover
 
 
 async def test_cover_on_open(client: HAClient, fake_ha: FakeHA) -> None:
@@ -463,7 +457,6 @@ async def test_cover_on_position_change(client: HAClient, fake_ha: FakeHA) -> No
     assert captured == [(50, 75)]
 
 
-# ============================================================ Climate
 
 
 async def test_climate_on_hvac_mode_change(client: HAClient, fake_ha: FakeHA) -> None:
@@ -534,7 +527,6 @@ async def test_climate_on_target_temperature_change(client: HAClient, fake_ha: F
     assert captured == [(22.0, 24.0)]
 
 
-# ============================================================ Sensor
 
 
 async def test_sensor_on_value_change(client: HAClient, fake_ha: FakeHA) -> None:
@@ -573,7 +565,6 @@ async def test_sensor_on_value_change_not_fired_when_same(
     assert captured == []
 
 
-# ============================================================ General mechanics
 
 
 async def test_async_granular_handler(client: HAClient, fake_ha: FakeHA) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -13,7 +13,6 @@ def test_resolve_short_and_full_name() -> None:
     reg = EntityRegistry()
     assert reg.resolve("light", "kitchen") == "light.kitchen"
     assert reg.resolve("light", "light.kitchen") == "light.kitchen"
-    # Cross-domain full id is returned verbatim (caller bears responsibility).
     assert reg.resolve("light", "switch.hall") == "switch.hall"
 
 
@@ -26,7 +25,7 @@ def test_require_missing() -> None:
 def test_register_and_lookup() -> None:
     reg = EntityRegistry()
     client = HAClient("http://x", "t")
-    client.registry = reg  # swap the registry so Light registers here
+    client.registry = reg
 
     from haclient import Light
 

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -86,7 +86,6 @@ async def test_get_state_reraises_non_404(fake_ha: FakeHA) -> None:
 async def test_url_normalisation(fake_ha: FakeHA) -> None:
     rc = RestClient(fake_ha.base_url, fake_ha.token)
     try:
-        # path without leading slash is prepended with /
         await rc._request("GET", "api/")
     finally:
         await rc.close()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -16,8 +16,6 @@ from .fake_ha import FakeHA
 @pytest_asyncio.fixture
 async def running_fake_ha() -> FakeHA:
     """A fake HA started by pytest-asyncio; used from a background thread."""
-    # Intentionally not async-yielding here – the SyncHAClient needs a
-    # stand-alone background server it can talk to.
     raise RuntimeError("Use fake_ha fixture instead")
 
 
@@ -42,8 +40,6 @@ def _run_sync_in_thread(fake_ha: FakeHA) -> dict[str, object]:
 
 
 async def test_sync_client_basic_operations(fake_ha: FakeHA) -> None:
-    # Run the sync client in a thread while the fake server runs on the
-    # main asyncio loop.
     results = await asyncio.get_running_loop().run_in_executor(None, _run_sync_in_thread, fake_ha)
     calls = results["calls"]
     assert isinstance(calls, list)
@@ -71,9 +67,7 @@ async def test_sync_proxy_passes_non_coroutine_attrs(fake_ha: FakeHA) -> None:
         try:
             client.connect()
             light = client.light("kitchen")
-            # entity_id is a plain attribute – should pass through.
             eid = light.entity_id
-            # repr should mention the wrapped entity.
             r = repr(light)
             return f"{eid}|{r}"
         finally:
@@ -110,11 +104,9 @@ async def test_sync_client_all_accessors(fake_ha: FakeHA) -> None:
                 "sensor": client.sensor("t").entity_id,
                 "binary_sensor": client.binary_sensor("b").entity_id,
             }
-            # exercise _SyncProxy __setattr__
             light = client.light("l")
             light.state = "on"
             assert light.state == "on"
-            # .client property is available
             assert client.client is not None
             return names
         finally:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -269,6 +269,7 @@ async def test_close_cancels_pending_request(fake_ha: FakeHA) -> None:
 async def test_reader_handles_non_json_text_frame(fake_ha: FakeHA) -> None:
     ws = await _make_ws(fake_ha, reconnect=False)
     try:
+
         async def send_garbage(server: FakeHA, server_ws: Any, msg: dict[str, Any]) -> None:
             await server_ws.send_str("not-json")
             await server_ws.send_json(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -96,7 +96,6 @@ async def test_subscribe_and_event(fake_ha: FakeHA) -> None:
             "state_changed",
             {"data": {"entity_id": "light.kitchen"}},
         )
-        # give reader a tick
         await asyncio.sleep(0.05)
         assert received
         assert received[0]["event_type"] == "state_changed"
@@ -123,7 +122,6 @@ async def test_reconnect_on_drop(fake_ha: FakeHA) -> None:
     """Force the server to close the WS and verify the client reconnects."""
     ws = await _make_ws(fake_ha, reconnect=True)
     try:
-        # Subscribe so we can verify re-subscription after reconnect.
         received: list[dict[str, Any]] = []
 
         async def handler(event: dict[str, Any]) -> None:
@@ -131,18 +129,15 @@ async def test_reconnect_on_drop(fake_ha: FakeHA) -> None:
 
         await ws.subscribe_events(handler, "state_changed")
 
-        # Kill the connection from the server side.
         for conn in list(fake_ha.connections):
             await conn.close()
 
-        # Wait until the reconnect loop re-establishes.
         for _ in range(50):
             await asyncio.sleep(0.1)
             if ws.connected:
                 break
         assert ws.connected
 
-        # After reconnect, push another event – handler should still fire.
         await fake_ha.push_event("state_changed", {"data": {"entity_id": "x"}})
         await asyncio.sleep(0.1)
         assert received
@@ -158,7 +153,6 @@ async def test_disconnect_listener(fake_ha: FakeHA) -> None:
     async def on_disconnect() -> None:
         called.set()
 
-    # Close from server side; client-side reader should notice.
     for conn in list(fake_ha.connections):
         await conn.close()
 
@@ -210,7 +204,6 @@ async def test_unsubscribe(fake_ha: FakeHA) -> None:
     try:
         sub_id = await ws.subscribe_events(handler, "state_changed")
         await ws.unsubscribe(sub_id)
-        # After unsubscribe the event should not be dispatched.
         await fake_ha.push_event("state_changed", {"data": {}})
         await asyncio.sleep(0.05)
         assert received == []
@@ -220,7 +213,7 @@ async def test_unsubscribe(fake_ha: FakeHA) -> None:
 
 async def test_cannot_connect_to_bad_port() -> None:
     ws = WebSocketClient(
-        "ws://127.0.0.1:1",  # port 1: nothing listening
+        "ws://127.0.0.1:1",
         "token",
         ping_interval=0,
         reconnect=False,
@@ -250,7 +243,6 @@ async def test_subscribe_events_failure_rolls_back(fake_ha: FakeHA) -> None:
     try:
         with pytest.raises(CommandError):
             await ws.subscribe_events(handler, "state_changed")
-        # Internal state should be clean again.
         assert not ws._subscriptions  # noqa: SLF001
         assert not ws._event_subs  # noqa: SLF001
     finally:
@@ -277,7 +269,6 @@ async def test_close_cancels_pending_request(fake_ha: FakeHA) -> None:
 async def test_reader_handles_non_json_text_frame(fake_ha: FakeHA) -> None:
     ws = await _make_ws(fake_ha, reconnect=False)
     try:
-        # Send a text frame that isn't JSON via a custom handler.
         async def send_garbage(server: FakeHA, server_ws: Any, msg: dict[str, Any]) -> None:
             await server_ws.send_str("not-json")
             await server_ws.send_json(
@@ -285,8 +276,6 @@ async def test_reader_handles_non_json_text_frame(fake_ha: FakeHA) -> None:
             )
 
         fake_ha.handlers["garbage"] = send_garbage
-        # send_command should still succeed because the garbage frame is
-        # logged & skipped.
         result = await ws.send_command({"type": "garbage"})
         assert result is None
     finally:
@@ -296,7 +285,6 @@ async def test_reader_handles_non_json_text_frame(fake_ha: FakeHA) -> None:
 async def test_keepalive_triggers_reconnect(fake_ha: FakeHA) -> None:
     """If the ping times out, the socket gets force-closed and reconnect kicks in."""
 
-    # Override ping so the server never responds to it.
     async def slow_ping(server: FakeHA, ws: Any, msg: dict[str, Any]) -> None:
         await asyncio.sleep(10)
 
@@ -310,23 +298,17 @@ async def test_keepalive_triggers_reconnect(fake_ha: FakeHA) -> None:
     )
     await ws.connect()
     try:
-        # Wait long enough for ping to time out and socket to drop.
         await asyncio.sleep(1.0)
-        # Reconnect loop should have re-established.
         for _ in range(40):
             if ws.connected:
                 break
             await asyncio.sleep(0.1)
-        # Either reconnected or at least we exercised the timeout path.
     finally:
         await ws.close()
 
 
 async def test_recv_json_close_frame(fake_ha: FakeHA) -> None:
     """_recv_json raises ConnectionClosedError on CLOSE frames during handshake."""
-    # Use drop_on_command to close the WS before auth completes isn't enough,
-    # we need to close before sending auth_required. Use reject + close approach.
-    # Simplest: start a separate aiohttp server for this test.
     app = web.Application()
 
     async def close_immediately(request: web.Request) -> web.WebSocketResponse:
@@ -456,7 +438,6 @@ async def test_reader_loop_ws_error_type(fake_ha: FakeHA) -> None:
     async def _on_dc() -> None:
         disconnected.set()
 
-    # Force-close server connections to trigger error/close in reader.
     for conn in list(fake_ha.connections):
         await conn.close()
 
@@ -469,7 +450,7 @@ async def test_connect_already_connected(fake_ha: FakeHA) -> None:
     ws = await _make_ws(fake_ha)
     try:
         assert ws.connected
-        await ws.connect()  # should return immediately
+        await ws.connect()
         assert ws.connected
     finally:
         await ws.close()
@@ -486,15 +467,12 @@ async def test_reconnect_failure_retries(fake_ha: FakeHA) -> None:
     """Reconnect loop retries on connection failure."""
     ws = await _make_ws(fake_ha, reconnect=True)
     try:
-        # Kill server connections and make auth fail temporarily.
         fake_ha.reject_auth = True
         for conn in list(fake_ha.connections):
             await conn.close()
 
-        # Let it try a couple of reconnects (which will fail).
         await asyncio.sleep(1.5)
 
-        # Now allow auth again.
         fake_ha.reject_auth = False
         for _ in range(50):
             await asyncio.sleep(0.1)
@@ -507,7 +485,6 @@ async def test_reconnect_failure_retries(fake_ha: FakeHA) -> None:
 
 async def test_keepalive_error_path(fake_ha: FakeHA) -> None:
     """Keepalive loop handles non-timeout errors gracefully."""
-    # Make ping raise a generic exception (not timeout).
     call_count = 0
 
     async def error_ping(
@@ -515,7 +492,6 @@ async def test_keepalive_error_path(fake_ha: FakeHA) -> None:
     ) -> None:
         nonlocal call_count
         call_count += 1
-        # Send back an error result instead of pong.
         await ws_resp.send_json(
             {
                 "id": msg["id"],
@@ -536,7 +512,6 @@ async def test_keepalive_error_path(fake_ha: FakeHA) -> None:
     await ws.connect()
     try:
         await asyncio.sleep(0.8)
-        # The keepalive loop should have hit the error path.
         assert call_count >= 1
     finally:
         await ws.close()
@@ -546,12 +521,10 @@ async def test_dispatch_unhandled_message_type(fake_ha: FakeHA) -> None:
     """Unhandled WS message types are logged but don't crash."""
     ws = await _make_ws(fake_ha, reconnect=False)
     try:
-        # Send a message with an unknown type directly from server.
         for conn in fake_ha.connections:
             if not conn.closed:
                 await conn.send_json({"type": "unknown_thing", "id": 999})
         await asyncio.sleep(0.05)
-        # Client should still be connected.
         assert ws.connected
     finally:
         await ws.close()


### PR DESCRIPTION
## Summary

- Add or improve PEP 257-compliant docstrings for all public and non-trivial internal functions, methods, and classes across the codebase
- Remove all inline comments, block comments, section banner comments, and commented-out code from `src/`, `tests/`, and `examples/`
- Preserve `# noqa` and `# pragma` directives required by tooling

## Details

**26 files changed** (+37 / -182 lines net reduction)

### Docstrings added/improved
- `websocket.py`: Added docstrings to `_ensure_session`, `_do_connect`, `_next_id`, `_recv_json`, `_reader_loop`, `_notify_disconnect`, `_dispatch`, `_invoke_handler`, `_reconnect_loop`, `_keepalive_loop`
- `client.py`: Added docstrings to `_on_state_changed_event`, `_get_or_create`
- `entity.py`: Added docstring to `_schedule`
- `rest.py`: Added docstrings to `_ensure_session`, `_headers`, `_url`, `_request`
- `sync.py`: Added docstrings to `_LoopThread._run`, `submit`, `stop`, `_ensure_coro`
- `registry.py`: Removed redundant section banners

### Docstrings intentionally omitted
- `__init__.py` (package): already has a module docstring
- `__contains__`, `__iter__`, `__len__`, `__repr__`, `__enter__`, `__exit__`, `__aenter__`, `__aexit__`: trivial dunder methods
- Test functions: self-explanatory from names and existing module docstrings
- Private trivial one-liners already documented by their callers

### Verification
- `ruff check .` — clean
- `mypy src/haclient/` — clean
- `pytest` — all 129 tests pass, 95.12% coverage (threshold: 95%)