### PR TITLE
[codex] Add Python 3.13 to HaClient CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [detect-stack]
     uses: ./.github/workflows/python-tests.yml
     with:
-      python-versions: ${{ vars.CI_PYTHON_TEST_VERSIONS || '["3.11","3.12"]' }}
+      python-versions: ${{ vars.CI_PYTHON_TEST_VERSIONS || '["3.11","3.12","3.13"]' }}
       install-spec: ${{ vars.CI_PYTHON_INSTALL_SPEC || '.[dev]' }}
       coverage-target: ${{ vars.CI_PYTHON_COVERAGE_TARGET || 'haclient' }}
       coverage-threshold: ${{ fromJSON(vars.CI_PYTHON_COVERAGE_THRESHOLD || '95') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Home Automation",
   "Typing :: Typed",
 ]


### PR DESCRIPTION
## What changed
- add Python 3.13 to the default test matrix in the main CI workflow
- add the Python 3.13 trove classifier to package metadata

## Why
`DeckUI` was already testing on Python 3.13, but `HaClient` still defaulted to only 3.11 and 3.12 in `.github/workflows/ci.yml` and did not advertise 3.13 support in `pyproject.toml`.

## Validation
- local `python3.13 -m pytest -q` in `HaClient`: 129 passed
- local `python3.13 -m pytest -q` in `DeckUI`: 902 passed, 1 warning
