### PR TITLE
Convert all docstrings to NumPy style

### DIFF
--- a/src/haclient/__init__.py
+++ b/src/haclient/__init__.py
@@ -2,8 +2,8 @@
 
 The two main entry points are:
 
-* :class:`HAClient` – the async client.
-* :class:`SyncHAClient` – a blocking wrapper suitable for scripts / REPL use.
+* `HAClient` -- the async client.
+* `SyncHAClient` -- a blocking wrapper suitable for scripts / REPL use.
 
 See the README for usage examples.
 """

--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -1,17 +1,19 @@
 """High-level Home Assistant client.
 
 This module ties together the REST and WebSocket layers, the entity registry
-and the domain helper classes into a single coherent API:
-
-.. code-block:: python
-
-    async with HAClient("http://localhost:8123", token="...") as ha:
-        light = ha.light("kitchen")
-        await light.turn_on(brightness=200)
+and the domain helper classes into a single coherent API.
 
 The client exposes one accessor per supported domain (``media_player``,
 ``light``, ``switch``, ...). The accessor performs name resolution, creates a
 domain object lazily if needed and returns the registered instance.
+
+Examples
+--------
+::
+
+    async with HAClient("http://localhost:8123", token="...") as ha:
+        light = ha.light("kitchen")
+        await light.turn_on(brightness=200)
 """
 
 from __future__ import annotations
@@ -58,22 +60,21 @@ class HAClient:
 
     Parameters
     ----------
-    base_url:
+    base_url : str
         The Home Assistant base URL (e.g. ``http://homeassistant.local:8123``).
-    token:
+    token : str
         Long-lived access token.
-    ws_url:
-        Optional explicit WebSocket URL. If omitted it is derived from
-        ``base_url``.
-    session:
-        Optional shared :class:`aiohttp.ClientSession`.
-    reconnect:
+    ws_url : str or None, optional
+        Explicit WebSocket URL. If omitted it is derived from *base_url*.
+    session : aiohttp.ClientSession or None, optional
+        Shared ``aiohttp.ClientSession``.
+    reconnect : bool, optional
         Whether to reconnect the WebSocket automatically.
-    ping_interval:
+    ping_interval : float, optional
         Seconds between keepalive pings (set to ``0`` to disable).
-    request_timeout:
+    request_timeout : float, optional
         Default timeout for WebSocket/REST operations.
-    verify_ssl:
+    verify_ssl : bool, optional
         Verify TLS certificates (``True`` by default).
     """
 
@@ -163,7 +164,13 @@ class HAClient:
         await self.rest.close()
 
     def _on_state_changed_event(self, event: dict[str, Any]) -> None:
-        """Dispatch a ``state_changed`` event to the appropriate entity."""
+        """Dispatch a ``state_changed`` event to the appropriate entity.
+
+        Parameters
+        ----------
+        event : dict
+            The raw event payload from the WebSocket.
+        """
         data = event.get("data") or {}
         eid = data.get("entity_id")
         if not isinstance(eid, str):
@@ -186,8 +193,24 @@ class HAClient:
         """Invoke a Home Assistant service.
 
         By default the call is made via the WebSocket API (which gives richer
-        error information). Set ``use_websocket=False`` to use the REST API
-        instead – useful before the WS connection is established.
+        error information). Set *use_websocket* to ``False`` to use the REST API
+        instead -- useful before the WS connection is established.
+
+        Parameters
+        ----------
+        domain : str
+            The service domain (e.g. ``"light"``).
+        service : str
+            The service name (e.g. ``"turn_on"``).
+        data : dict or None, optional
+            Service data payload.
+        use_websocket : bool, optional
+            If ``True`` (default), use the WebSocket API when connected.
+
+        Returns
+        -------
+        Any
+            The result payload from Home Assistant.
         """
         if use_websocket and self.ws.connected:
             payload: dict[str, Any] = {
@@ -208,7 +231,27 @@ class HAClient:
             entity._apply_state(index.get(entity.entity_id))  # noqa: SLF001
 
     def _get_or_create(self, domain: str, name: str, cls: type[_E]) -> _E:
-        """Return the entity for *name* in *domain*, creating it if needed."""
+        """Return the entity for *name* in *domain*, creating it if needed.
+
+        Parameters
+        ----------
+        domain : str
+            The Home Assistant domain (e.g. ``"light"``).
+        name : str
+            Short object-id or fully-qualified entity id.
+        cls : type
+            The ``Entity`` subclass to instantiate if absent.
+
+        Returns
+        -------
+        Entity
+            The existing or newly created entity instance.
+
+        Raises
+        ------
+        HAClientError
+            If the entity exists but is registered under a different class.
+        """
         entity_id = self.registry.resolve(domain, name)
         existing = self.registry.get(entity_id)
         if existing is not None:
@@ -221,43 +264,120 @@ class HAClient:
         return cls(entity_id, self)
 
     def media_player(self, name: str) -> MediaPlayer:
-        """Return the :class:`MediaPlayer` for ``name`` (creating it if needed)."""
+        """Return the `MediaPlayer` for *name*, creating it if needed.
+
+        Parameters
+        ----------
+        name : str
+            Short object-id or fully-qualified entity id.
+
+        Returns
+        -------
+        MediaPlayer
+            The media player entity.
+        """
         from .domains.media_player import MediaPlayer as _MediaPlayer
 
         return self._get_or_create("media_player", name, _MediaPlayer)
 
     def light(self, name: str) -> Light:
-        """Return the :class:`Light` for ``name``."""
+        """Return the `Light` for *name*, creating it if needed.
+
+        Parameters
+        ----------
+        name : str
+            Short object-id or fully-qualified entity id.
+
+        Returns
+        -------
+        Light
+            The light entity.
+        """
         from .domains.light import Light as _Light
 
         return self._get_or_create("light", name, _Light)
 
     def switch(self, name: str) -> Switch:
-        """Return the :class:`Switch` for ``name``."""
+        """Return the `Switch` for *name*, creating it if needed.
+
+        Parameters
+        ----------
+        name : str
+            Short object-id or fully-qualified entity id.
+
+        Returns
+        -------
+        Switch
+            The switch entity.
+        """
         from .domains.switch import Switch as _Switch
 
         return self._get_or_create("switch", name, _Switch)
 
     def climate(self, name: str) -> Climate:
-        """Return the :class:`Climate` for ``name``."""
+        """Return the `Climate` for *name*, creating it if needed.
+
+        Parameters
+        ----------
+        name : str
+            Short object-id or fully-qualified entity id.
+
+        Returns
+        -------
+        Climate
+            The climate entity.
+        """
         from .domains.climate import Climate as _Climate
 
         return self._get_or_create("climate", name, _Climate)
 
     def cover(self, name: str) -> Cover:
-        """Return the :class:`Cover` for ``name``."""
+        """Return the `Cover` for *name*, creating it if needed.
+
+        Parameters
+        ----------
+        name : str
+            Short object-id or fully-qualified entity id.
+
+        Returns
+        -------
+        Cover
+            The cover entity.
+        """
         from .domains.cover import Cover as _Cover
 
         return self._get_or_create("cover", name, _Cover)
 
     def sensor(self, name: str) -> Sensor:
-        """Return the :class:`Sensor` for ``name`` (read-only)."""
+        """Return the `Sensor` for *name* (read-only), creating it if needed.
+
+        Parameters
+        ----------
+        name : str
+            Short object-id or fully-qualified entity id.
+
+        Returns
+        -------
+        Sensor
+            The sensor entity.
+        """
         from .domains.sensor import Sensor as _Sensor
 
         return self._get_or_create("sensor", name, _Sensor)
 
     def binary_sensor(self, name: str) -> BinarySensor:
-        """Return the :class:`BinarySensor` for ``name`` (read-only)."""
+        """Return the `BinarySensor` for *name* (read-only), creating it if needed.
+
+        Parameters
+        ----------
+        name : str
+            Short object-id or fully-qualified entity id.
+
+        Returns
+        -------
+        BinarySensor
+            The binary sensor entity.
+        """
         from .domains.binary_sensor import BinarySensor as _BinarySensor
 
         return self._get_or_create("binary_sensor", name, _BinarySensor)

--- a/src/haclient/domains/__init__.py
+++ b/src/haclient/domains/__init__.py
@@ -1,4 +1,4 @@
-"""Domain-specific :class:`~haclient.entity.Entity` subclasses."""
+"""Domain-specific `Entity` subclasses."""
 
 from .binary_sensor import BinarySensor
 from .climate import Climate

--- a/src/haclient/domains/climate.py
+++ b/src/haclient/domains/climate.py
@@ -38,7 +38,7 @@ class Climate(Entity):
 
     @property
     def hvac_mode(self) -> str:
-        """The active HVAC mode (same as :attr:`state`)."""
+        """The active HVAC mode (same as `state`)."""
         return self.state
 
     @property
@@ -54,7 +54,17 @@ class Climate(Entity):
         hvac_mode: str | None = None,
         **extra: Any,
     ) -> None:
-        """Set the target temperature (optionally changing HVAC mode)."""
+        """Set the target temperature.
+
+        Parameters
+        ----------
+        temperature : float
+            Desired target temperature.
+        hvac_mode : str or None, optional
+            Optionally change the HVAC mode at the same time.
+        **extra : Any
+            Additional service data forwarded to Home Assistant.
+        """
         data: dict[str, Any] = {"temperature": float(temperature), **extra}
         if hvac_mode is not None:
             data["hvac_mode"] = hvac_mode

--- a/src/haclient/domains/cover.py
+++ b/src/haclient/domains/cover.py
@@ -53,7 +53,13 @@ class Cover(Entity):
         await self.call_service("stop_cover")
 
     async def set_position(self, position: int) -> None:
-        """Set the cover position (0 closed, 100 open)."""
+        """Set the cover position.
+
+        Parameters
+        ----------
+        position : int
+            Target position (0 = closed, 100 = open).
+        """
         await self.call_service("set_cover_position", {"position": int(position)})
 
     async def toggle(self) -> None:

--- a/src/haclient/domains/light.py
+++ b/src/haclient/domains/light.py
@@ -82,7 +82,23 @@ class Light(Entity):
         transition: float | None = None,
         **extra: Any,
     ) -> None:
-        """Turn the light on, optionally setting brightness/color/transition."""
+        """Turn the light on, optionally setting brightness/color/transition.
+
+        Parameters
+        ----------
+        brightness : int or None, optional
+            Brightness value (0--255).
+        rgb_color : tuple of int or list of int or None, optional
+            RGB color as a 3-element sequence.
+        color_temp : int or None, optional
+            Color temperature in mireds.
+        kelvin : int or None, optional
+            Color temperature in Kelvin.
+        transition : float or None, optional
+            Transition time in seconds.
+        **extra : Any
+            Additional service data forwarded to Home Assistant.
+        """
         data: dict[str, Any] = dict(extra)
         if brightness is not None:
             data["brightness"] = int(brightness)
@@ -97,7 +113,13 @@ class Light(Entity):
         await self.call_service("turn_on", data or None)
 
     async def turn_off(self, *, transition: float | None = None) -> None:
-        """Turn the light off."""
+        """Turn the light off.
+
+        Parameters
+        ----------
+        transition : float or None, optional
+            Transition time in seconds.
+        """
         data: dict[str, Any] = {}
         if transition is not None:
             data["transition"] = transition

--- a/src/haclient/domains/media_player.py
+++ b/src/haclient/domains/media_player.py
@@ -1,7 +1,7 @@
 """``media_player`` domain implementation.
 
-This module also contains the :class:`FavoriteItem` helper returned by
-:meth:`MediaPlayer.favorites`, which recursively traverses the
+This module also contains the `FavoriteItem` helper returned by
+`MediaPlayer.favorites`, which recursively traverses the
 ``media_player/browse_media`` tree and flattens it into a list of directly
 playable items.
 """
@@ -23,7 +23,7 @@ _MAX_BROWSE_DEPTH = 6
 
 
 def _now_playing_from_attrs(attrs: dict[str, Any]) -> NowPlaying:
-    """Build a :class:`NowPlaying` from a raw HA attributes dict."""
+    """Build a `NowPlaying` from a raw HA attributes dict."""
     features = attrs.get("supported_features") or 0
     return NowPlaying(
         source=attrs.get("source"),
@@ -49,12 +49,45 @@ class NowPlaying:
     """Structured snapshot of the media currently playing on a media player.
 
     Groups all identity-related media attributes into a single object.
-    Position/progress fields are intentionally excluded — they change
+    Position/progress fields are intentionally excluded -- they change
     continuously during playback and do not represent a change in *what*
     is playing.
 
     Instances are frozen (immutable and hashable) so two snapshots can be
     compared with ``==`` to detect whether the playing media changed.
+
+    Attributes
+    ----------
+    source : str or None
+        Active input source.
+    title : str or None
+        Media title.
+    artist : str or None
+        Media artist.
+    album : str or None
+        Album name.
+    channel : str or None
+        Channel name.
+    content_type : str or None
+        Media content type identifier.
+    content_id : str or None
+        Media content id.
+    duration : int or None
+        Media duration in seconds.
+    entity_picture : str or None
+        URL of the entity picture / album art.
+    queue_position : int or None
+        Current position in the play queue.
+    queue_size : int or None
+        Total items in the play queue.
+    playlist : str or None
+        Playlist name.
+    repeat : str or None
+        Repeat mode.
+    next : bool
+        Whether skip-next is supported.
+    previous : bool
+        Whether skip-previous is supported.
     """
 
     source: str | None = None
@@ -77,19 +110,36 @@ class NowPlaying:
 class FavoriteItem:
     """A flattened, directly-playable entry discovered via ``browse_media``.
 
-    The item remembers which :class:`MediaPlayer` it belongs to, along with the
+    The item remembers which `MediaPlayer` it belongs to, along with the
     ``media_content_id`` / ``media_content_type`` pair needed to play it. Call
-    :meth:`play` to start playback on the owning media player.
+    `play` to start playback on the owning media player.
 
     Extra metadata is captured to make the item easy to render in a UI:
 
-    * ``thumbnail`` – an optional image URL from Home Assistant.
-    * ``category`` – a human-readable label for the kind of favorite (e.g.
+    * ``thumbnail`` -- an optional image URL from Home Assistant.
+    * ``category`` -- a human-readable label for the kind of favorite (e.g.
       ``"Radio"``, ``"Albums"``, ``"Playlists"``). It is derived from the title
       of the parent folder it was found under when available, otherwise falls
       back to ``media_class``.
-    * ``media_class`` – the raw ``media_class`` reported by HA (e.g.
+    * ``media_class`` -- the raw ``media_class`` reported by HA (e.g.
       ``"genre"``, ``"album"``, ``"playlist"``, ``"track"``).
+
+    Parameters
+    ----------
+    title : str
+        Display title.
+    media_content_id : str
+        Content identifier for playback.
+    media_content_type : str
+        Content type for playback.
+    player : MediaPlayer
+        The owning media player.
+    thumbnail : str or None, optional
+        Image URL.
+    category : str or None, optional
+        Human-readable category label.
+    media_class : str or None, optional
+        Raw media class from Home Assistant.
     """
 
     __slots__ = (
@@ -122,7 +172,7 @@ class FavoriteItem:
         self._player = player
 
     async def play(self) -> None:
-        """Play this favorite on its :class:`MediaPlayer`."""
+        """Play this favorite on its `MediaPlayer`."""
         await self._player.play_media(self.media_content_type, self.media_content_id)
 
     def __repr__(self) -> str:
@@ -161,7 +211,17 @@ class MediaPlayer(Entity):
         queue_position, queue_size, playlist, repeat, next, previous)
         but **not** on position/progress updates.
 
-        Callback: ``(old: NowPlaying, new: NowPlaying)``.
+        The callback receives ``(old: NowPlaying, new: NowPlaying)``.
+
+        Parameters
+        ----------
+        func : callable
+            Callback with signature ``(old, new)``.
+
+        Returns
+        -------
+        callable
+            The same *func*, for use as a decorator.
         """
         self._media_change_listeners.append(func)
         return func
@@ -253,13 +313,30 @@ class MediaPlayer(Entity):
         await self.call_service("media_previous_track")
 
     async def set_volume(self, level: float) -> None:
-        """Set the volume level (``0.0`` – ``1.0``)."""
+        """Set the volume level.
+
+        Parameters
+        ----------
+        level : float
+            Volume level between ``0.0`` and ``1.0``.
+
+        Raises
+        ------
+        ValueError
+            If *level* is outside the ``[0.0, 1.0]`` range.
+        """
         if not 0.0 <= level <= 1.0:
             raise ValueError("Volume level must be between 0.0 and 1.0")
         await self.call_service("volume_set", {"volume_level": float(level)})
 
     async def mute(self, muted: bool = True) -> None:
-        """Mute or unmute the media player."""
+        """Mute or unmute the media player.
+
+        Parameters
+        ----------
+        muted : bool, optional
+            ``True`` to mute, ``False`` to unmute.
+        """
         await self.call_service("volume_mute", {"is_volume_muted": bool(muted)})
 
     async def turn_on(self) -> None:
@@ -271,7 +348,13 @@ class MediaPlayer(Entity):
         await self.call_service("turn_off")
 
     async def select_source(self, source: str) -> None:
-        """Select an input source."""
+        """Select an input source.
+
+        Parameters
+        ----------
+        source : str
+            The source name to select.
+        """
         await self.call_service("select_source", {"source": source})
 
     async def play_media(
@@ -280,7 +363,17 @@ class MediaPlayer(Entity):
         media_content_id: str,
         **extra: Any,
     ) -> None:
-        """Play a specific media item (by content type / id)."""
+        """Play a specific media item.
+
+        Parameters
+        ----------
+        media_content_type : str
+            The content type (e.g. ``"music"``).
+        media_content_id : str
+            The content identifier.
+        **extra : Any
+            Additional service data forwarded to Home Assistant.
+        """
         data: dict[str, Any] = {
             "media_content_type": media_content_type,
             "media_content_id": media_content_id,
@@ -295,8 +388,22 @@ class MediaPlayer(Entity):
     ) -> dict[str, Any]:
         """Issue a single ``media_player/browse_media`` WebSocket command.
 
-        Returns the raw result dictionary from Home Assistant. Raises
-        :class:`HAClientError` if the command fails.
+        Parameters
+        ----------
+        media_content_type : str or None, optional
+            Content type to browse.
+        media_content_id : str or None, optional
+            Content id to browse into.
+
+        Returns
+        -------
+        dict
+            The raw result dictionary from Home Assistant.
+
+        Raises
+        ------
+        HAClientError
+            If the command fails or returns an unexpected response.
         """
         payload: dict[str, Any] = {
             "type": "media_player/browse_media",
@@ -319,20 +426,25 @@ class MediaPlayer(Entity):
     ) -> list[FavoriteItem]:
         """Return a flattened list of playable items in the media tree.
 
-        The method recursively walks the ``browse_media`` tree rooted at the
-        entity and collects every entry that Home Assistant marks as
-        ``can_play`` (and that has a ``media_content_id``).
+        Recursively walks the ``browse_media`` tree rooted at the entity and
+        collects every entry that Home Assistant marks as ``can_play`` (and
+        that has a ``media_content_id``).
 
         If the media player doesn't support browsing, an empty list is
         returned (no exception is raised).
 
         Parameters
         ----------
-        max_depth:
+        max_depth : int, optional
             Maximum recursion depth. Defaults to a sensible cap to avoid
             pathological trees.
-        max_nodes:
+        max_nodes : int, optional
             Hard upper bound on total nodes visited (also a safety net).
+
+        Returns
+        -------
+        list of FavoriteItem
+            The discovered playable items.
         """
         try:
             root = await self.browse_media()

--- a/src/haclient/entity.py
+++ b/src/haclient/entity.py
@@ -1,7 +1,7 @@
-"""Base :class:`Entity` implementation.
+"""Base `Entity` implementation.
 
-Entities are bound to an :class:`haclient.client.HAClient` instance and
-automatically receive state updates from WebSocket ``state_changed`` events.
+Entities are bound to an `HAClient` instance and automatically receive
+state updates from WebSocket ``state_changed`` events.
 """
 
 from __future__ import annotations
@@ -28,11 +28,27 @@ class Entity:
     """Represent a single Home Assistant entity.
 
     Subclasses map to specific domains (``media_player``, ``light``, ...) and
-    should override :attr:`domain` and add domain-specific methods.
+    should override `domain` and add domain-specific methods.
 
-    The :attr:`state` string and :attr:`attributes` dictionary reflect the most
-    recent state known to the client. They are refreshed automatically when the
+    The `state` string and `attributes` dictionary reflect the most recent
+    state known to the client. They are refreshed automatically when the
     client receives ``state_changed`` events for this entity.
+
+    Parameters
+    ----------
+    entity_id : str
+        Fully-qualified entity id (e.g. ``"light.kitchen"``).
+    client : HAClient
+        The owning client instance.
+
+    Attributes
+    ----------
+    entity_id : str
+        The fully-qualified entity id.
+    state : str
+        Current state string (e.g. ``"on"``, ``"off"``, ``"unavailable"``).
+    attributes : dict
+        Current entity attributes from Home Assistant.
     """
 
     domain: str = ""
@@ -144,6 +160,18 @@ class Entity:
 
         The callback receives ``(old_value, new_value)`` and is only called
         when the attribute value actually changes between events.
+
+        Parameters
+        ----------
+        attr_key : str
+            The attribute key to watch.
+        func : callable
+            Callback with signature ``(old_value, new_value)``.
+
+        Returns
+        -------
+        callable
+            The same *func*, for use as a decorator.
         """
         self._attr_listeners.setdefault(attr_key, []).append(func)
         return func
@@ -152,7 +180,19 @@ class Entity:
         """Register a listener for transitions *to* a specific state.
 
         The callback receives ``(old_state_str, new_state_str)`` and is only
-        called when the entity's state string transitions to ``to_state``.
+        called when the entity's state string transitions to *to_state*.
+
+        Parameters
+        ----------
+        to_state : str
+            The target state to listen for.
+        func : callable
+            Callback with signature ``(old_state_str, new_state_str)``.
+
+        Returns
+        -------
+        callable
+            The same *func*, for use as a decorator.
         """
         self._state_transition_listeners.setdefault(to_state, []).append(func)
         return func
@@ -162,6 +202,16 @@ class Entity:
 
         The callback receives ``(old_state_str, new_state_str)`` and fires
         whenever the state string changes (regardless of target value).
+
+        Parameters
+        ----------
+        func : callable
+            Callback with signature ``(old_state_str, new_state_str)``.
+
+        Returns
+        -------
+        callable
+            The same *func*, for use as a decorator.
         """
         self._state_value_listeners.append(func)
         return func
@@ -180,12 +230,22 @@ class Entity:
             self._state_value_listeners.remove(func)
 
     def on_state_change(self, func: F) -> F:
-        """Register ``func`` as a listener for state changes on this entity.
+        """Register *func* as a listener for state changes on this entity.
 
         May be used as a decorator. The callback receives the previous and new
         raw state objects (``dict`` or ``None``). Coroutine functions are fully
         supported and will be scheduled on the client's event loop without
         blocking the dispatcher.
+
+        Parameters
+        ----------
+        func : callable
+            Callback with signature ``(old_state, new_state)``.
+
+        Returns
+        -------
+        callable
+            The same *func*, for use as a decorator.
         """
         self._listeners.append(func)
         return func
@@ -214,9 +274,21 @@ class Entity:
     ) -> Any:
         """Call a Home Assistant service targeting this entity.
 
-        ``service`` is the service name within ``domain`` (defaulting to this
-        entity's domain). ``entity_id`` is injected automatically into the
-        service data.
+        The ``entity_id`` is injected automatically into the service data.
+
+        Parameters
+        ----------
+        service : str
+            Service name within the domain.
+        data : dict or None, optional
+            Additional service data.
+        domain : str or None, optional
+            Override domain (defaults to this entity's domain).
+
+        Returns
+        -------
+        Any
+            The result from Home Assistant.
         """
         payload: dict[str, Any] = {"entity_id": self.entity_id}
         if data:

--- a/src/haclient/exceptions.py
+++ b/src/haclient/exceptions.py
@@ -1,6 +1,6 @@
 """Exception hierarchy for the Home Assistant client.
 
-All library-specific exceptions derive from :class:`HAClientError` so callers
+All library-specific exceptions derive from `HAClientError` so callers
 can catch a single base type if they do not care about the specific failure.
 """
 
@@ -20,7 +20,15 @@ class ConnectionClosedError(HAClientError):
 
 
 class CommandError(HAClientError):
-    """Raised when Home Assistant returns an error for a WebSocket command."""
+    """Raised when Home Assistant returns an error for a WebSocket command.
+
+    Attributes
+    ----------
+    code : str
+        The error code from Home Assistant.
+    message : str
+        The human-readable error message.
+    """
 
     def __init__(self, code: str, message: str) -> None:
         super().__init__(f"{code}: {message}")

--- a/src/haclient/registry.py
+++ b/src/haclient/registry.py
@@ -1,9 +1,9 @@
 """Entity registry.
 
-The registry stores :class:`haclient.entity.Entity` instances keyed by their
-``entity_id`` and supports lookup by short (object) name scoped to a domain.
-It is owned by each :class:`haclient.client.HAClient` instance to avoid the
-pitfalls of global singletons in test and multi-client scenarios.
+The registry stores `Entity` instances keyed by their ``entity_id`` and
+supports lookup by short (object) name scoped to a domain. It is owned by
+each `HAClient` instance to avoid the pitfalls of global singletons in
+test and multi-client scenarios.
 """
 
 from __future__ import annotations
@@ -18,7 +18,13 @@ if TYPE_CHECKING:
 
 
 class EntityRegistry:
-    """In-memory mapping of ``entity_id`` → :class:`Entity`."""
+    """In-memory mapping of ``entity_id`` to `Entity`.
+
+    Attributes
+    ----------
+    _entities : dict
+        Internal mapping of entity id strings to entity instances.
+    """
 
     def __init__(self) -> None:
         self._entities: dict[str, Entity] = {}
@@ -36,7 +42,23 @@ class EntityRegistry:
         return self._entities.get(entity_id)
 
     def require(self, entity_id: str) -> Entity:
-        """Return the entity for ``entity_id`` or raise :class:`EntityNotFoundError`."""
+        """Return the entity for *entity_id* or raise `EntityNotFoundError`.
+
+        Parameters
+        ----------
+        entity_id : str
+            Fully-qualified entity id.
+
+        Returns
+        -------
+        Entity
+            The registered entity.
+
+        Raises
+        ------
+        EntityNotFoundError
+            If no entity is registered for *entity_id*.
+        """
         entity = self._entities.get(entity_id)
         if entity is None:
             raise EntityNotFoundError(f"Entity not found: {entity_id}")
@@ -56,25 +78,39 @@ class EntityRegistry:
         self._entities.clear()
 
     def resolve(self, domain: str, name: str) -> str:
-        """Resolve a short name to a full ``entity_id`` within ``domain``.
+        """Resolve a short name to a full ``entity_id`` within *domain*.
 
-        ``name`` may be either:
-
-        * the *object id* (``"livingroom"``), or
-        * the fully-qualified ``entity_id`` (``"media_player.livingroom"``).
+        *name* may be either the object id (``"livingroom"``) or the
+        fully-qualified ``entity_id`` (``"media_player.livingroom"``).
 
         Parameters
         ----------
-        domain:
+        domain : str
             The Home Assistant domain (e.g. ``"media_player"``).
-        name:
+        name : str
             The short name or full entity id to resolve.
+
+        Returns
+        -------
+        str
+            The fully-qualified entity id.
         """
         if "." in name:
             return name
         return f"{domain}.{name}"
 
     def in_domain(self, domain: str) -> list[Entity]:
-        """Return all registered entities belonging to ``domain``."""
+        """Return all registered entities belonging to *domain*.
+
+        Parameters
+        ----------
+        domain : str
+            The Home Assistant domain (e.g. ``"light"``).
+
+        Returns
+        -------
+        list of Entity
+            Entities whose id starts with ``{domain}.``.
+        """
         prefix = f"{domain}."
         return [e for eid, e in self._entities.items() if eid.startswith(prefix)]

--- a/src/haclient/rest.py
+++ b/src/haclient/rest.py
@@ -1,13 +1,13 @@
 """Thin async wrapper around the Home Assistant REST API.
 
-Only the endpoints needed by :class:`haclient.client.HAClient` are exposed:
+Only the endpoints needed by `HAClient` are exposed:
 
-* ``GET  /api/``              – ping / connectivity check
-* ``GET  /api/states``        – fetch all states
-* ``GET  /api/states/{id}``   – fetch a single state
-* ``POST /api/services/{domain}/{service}`` – invoke a service
+* ``GET  /api/``              -- ping / connectivity check
+* ``GET  /api/states``        -- fetch all states
+* ``GET  /api/states/{id}``   -- fetch a single state
+* ``POST /api/services/{domain}/{service}`` -- invoke a service
 
-Internally we use :mod:`aiohttp` because the WebSocket layer already depends on
+Internally we use ``aiohttp`` because the WebSocket layer already depends on
 it, keeping the dependency surface minimal.
 """
 
@@ -25,7 +25,21 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class RestClient:
-    """Async client for the Home Assistant REST API."""
+    """Async client for the Home Assistant REST API.
+
+    Parameters
+    ----------
+    base_url : str
+        The Home Assistant base URL.
+    token : str
+        Long-lived access token.
+    session : aiohttp.ClientSession or None, optional
+        Shared HTTP session. If not provided one is created automatically.
+    timeout : float, optional
+        Request timeout in seconds.
+    verify_ssl : bool, optional
+        Verify TLS certificates.
+    """
 
     def __init__(
         self,
@@ -76,7 +90,31 @@ class RestClient:
         *,
         json: Any | None = None,
     ) -> Any:
-        """Perform an HTTP request and return the parsed response."""
+        """Perform an HTTP request and return the parsed response.
+
+        Parameters
+        ----------
+        method : str
+            HTTP method (e.g. ``"GET"``, ``"POST"``).
+        path : str
+            Relative API path (e.g. ``"/api/states"``).
+        json : Any or None, optional
+            JSON-serialisable body.
+
+        Returns
+        -------
+        Any
+            Parsed JSON response, or raw text for non-JSON responses.
+
+        Raises
+        ------
+        AuthenticationError
+            If the server returns HTTP 401.
+        HAClientError
+            On any HTTP error >= 400 or connection failure.
+        TimeoutError
+            If the request exceeds the configured timeout.
+        """
         session = await self._ensure_session()
         url = self._url(path)
         try:
@@ -102,19 +140,47 @@ class RestClient:
             raise HAClientError(f"HTTP request failed: {err}") from err
 
     async def ping(self) -> bool:
-        """Return ``True`` if the Home Assistant API is reachable."""
+        """Check whether the Home Assistant API is reachable.
+
+        Returns
+        -------
+        bool
+            ``True`` if the API responds successfully.
+        """
         await self._request("GET", "/api/")
         return True
 
     async def get_states(self) -> list[dict[str, Any]]:
-        """Return all entity states currently known to Home Assistant."""
+        """Return all entity states currently known to Home Assistant.
+
+        Returns
+        -------
+        list of dict
+            A list of state objects.
+
+        Raises
+        ------
+        HAClientError
+            If the response is not a list.
+        """
         data = await self._request("GET", "/api/states")
         if not isinstance(data, list):
             raise HAClientError("Unexpected response from /api/states")
         return data
 
     async def get_state(self, entity_id: str) -> dict[str, Any] | None:
-        """Return the state object for ``entity_id`` or ``None`` if not found."""
+        """Return the state object for *entity_id*, or ``None`` if not found.
+
+        Parameters
+        ----------
+        entity_id : str
+            Fully-qualified entity id (e.g. ``"light.kitchen"``).
+
+        Returns
+        -------
+        dict or None
+            The state object, or ``None`` on HTTP 404.
+        """
         try:
             data = await self._request("GET", f"/api/states/{entity_id}")
         except HAClientError as err:
@@ -133,8 +199,20 @@ class RestClient:
     ) -> list[dict[str, Any]]:
         """Invoke a Home Assistant service via REST.
 
-        Returns the list of states that were changed (if any). Home Assistant
-        returns this list directly in the response body.
+        Parameters
+        ----------
+        domain : str
+            The service domain (e.g. ``"light"``).
+        service : str
+            The service name (e.g. ``"turn_on"``).
+        data : dict or None, optional
+            Service data payload.
+
+        Returns
+        -------
+        list of dict
+            The list of states that were changed (if any). Home Assistant
+            returns this list directly in the response body.
         """
         payload = data or {}
         result = await self._request("POST", f"/api/services/{domain}/{service}", json=payload)

--- a/src/haclient/sync.py
+++ b/src/haclient/sync.py
@@ -1,13 +1,13 @@
-"""Synchronous convenience wrapper around :class:`HAClient`.
+"""Synchronous convenience wrapper around `HAClient`.
 
 The wrapper runs a dedicated event loop in a background thread and submits
-coroutines to it via :func:`asyncio.run_coroutine_threadsafe`. This allows
+coroutines to it via `asyncio.run_coroutine_threadsafe`. This allows
 users in plain scripts / REPL sessions to consume the library without thinking
 about ``asyncio`` or risking event-loop conflicts (e.g. inside Jupyter).
 
-Example
--------
-.. code-block:: python
+Examples
+--------
+::
 
     from haclient import SyncHAClient
 
@@ -58,7 +58,20 @@ class _LoopThread:
                 self.loop.close()
 
     def submit(self, coro: Awaitable[T], *, timeout: float | None = None) -> T:
-        """Submit an awaitable to the background loop and block for the result."""
+        """Submit an awaitable to the background loop and block for the result.
+
+        Parameters
+        ----------
+        coro : Awaitable[T]
+            The awaitable to execute.
+        timeout : float or None, optional
+            Maximum seconds to wait for the result.
+
+        Returns
+        -------
+        T
+            The result of the awaitable.
+        """
         if not inspect.isawaitable(coro):  # pragma: no cover - defensive
             raise TypeError("submit() expects an awaitable")
         future = asyncio.run_coroutine_threadsafe(_ensure_coro(coro), self.loop)
@@ -104,9 +117,9 @@ class _SyncProxy:
 
 
 class SyncHAClient:
-    """Synchronous counterpart of :class:`HAClient`.
+    """Synchronous counterpart of `HAClient`.
 
-    All public methods of :class:`HAClient` are exposed as blocking calls. All
+    All public methods of `HAClient` are exposed as blocking calls. All
     async methods of returned entities are automatically wrapped in a sync
     proxy so consumers can call ``player.play()`` without ``await``.
     """
@@ -121,7 +134,7 @@ class SyncHAClient:
 
     @property
     def client(self) -> HAClient:
-        """Return the underlying :class:`HAClient` instance."""
+        """Return the underlying `HAClient` instance."""
         return self._client
 
     def connect(self) -> None:
@@ -151,29 +164,29 @@ class SyncHAClient:
         self._loop_thread.submit(self._client.refresh_all())
 
     def media_player(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async :class:`MediaPlayer`."""
+        """Return a sync proxy wrapping the async `MediaPlayer`."""
         return _SyncProxy(self._client.media_player(name), self._loop_thread)
 
     def light(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async :class:`Light`."""
+        """Return a sync proxy wrapping the async `Light`."""
         return _SyncProxy(self._client.light(name), self._loop_thread)
 
     def switch(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async :class:`Switch`."""
+        """Return a sync proxy wrapping the async `Switch`."""
         return _SyncProxy(self._client.switch(name), self._loop_thread)
 
     def climate(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async :class:`Climate`."""
+        """Return a sync proxy wrapping the async `Climate`."""
         return _SyncProxy(self._client.climate(name), self._loop_thread)
 
     def cover(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async :class:`Cover`."""
+        """Return a sync proxy wrapping the async `Cover`."""
         return _SyncProxy(self._client.cover(name), self._loop_thread)
 
     def sensor(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async :class:`Sensor`."""
+        """Return a sync proxy wrapping the async `Sensor`."""
         return _SyncProxy(self._client.sensor(name), self._loop_thread)
 
     def binary_sensor(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async :class:`BinarySensor`."""
+        """Return a sync proxy wrapping the async `BinarySensor`."""
         return _SyncProxy(self._client.binary_sensor(name), self._loop_thread)

--- a/src/haclient/websocket.py
+++ b/src/haclient/websocket.py
@@ -41,19 +41,21 @@ class WebSocketClient:
 
     Parameters
     ----------
-    url:
+    url : str
         Fully-qualified WebSocket URL (e.g. ``ws://localhost:8123/api/websocket``).
-    token:
+    token : str
         Long-lived access token.
-    session:
-        Optional pre-existing :class:`aiohttp.ClientSession`. If not provided
-        one will be created and closed automatically.
-    reconnect:
+    session : aiohttp.ClientSession or None, optional
+        Pre-existing ``aiohttp.ClientSession``. If not provided one will be
+        created and closed automatically.
+    reconnect : bool, optional
         Whether to reconnect automatically when the socket drops.
-    ping_interval:
+    ping_interval : float, optional
         Seconds between keepalive pings. Set to ``0`` to disable.
-    request_timeout:
+    request_timeout : float, optional
         Default timeout (seconds) for individual WebSocket commands.
+    verify_ssl : bool, optional
+        Verify TLS certificates.
     """
 
     def __init__(
@@ -171,7 +173,18 @@ class WebSocketClient:
     def on_disconnect(
         self, handler: Callable[[], Awaitable[None] | None]
     ) -> Callable[[], Awaitable[None] | None]:
-        """Register ``handler`` to be called when the connection drops."""
+        """Register *handler* to be called when the connection drops.
+
+        Parameters
+        ----------
+        handler : callable
+            A sync or async callable taking no arguments.
+
+        Returns
+        -------
+        callable
+            The same *handler*, for use as a decorator.
+        """
         self._disconnect_listeners.append(handler)
         return handler
 
@@ -207,10 +220,26 @@ class WebSocketClient:
     ) -> Any:
         """Send a command and await its ``result`` frame.
 
-        Returns the ``result`` payload (the value of the ``result`` key in the
-        response). Raises :class:`CommandError` if Home Assistant returns a
-        ``success: false`` response, and :class:`HATimeoutError` if no reply
-        arrives within ``timeout`` seconds.
+        Parameters
+        ----------
+        payload : dict
+            The command payload (without ``id``; one is assigned automatically).
+        timeout : float or None, optional
+            Seconds to wait for the reply. Falls back to *request_timeout*.
+
+        Returns
+        -------
+        Any
+            The value of the ``result`` key in the response.
+
+        Raises
+        ------
+        CommandError
+            If Home Assistant returns ``success: false``.
+        TimeoutError
+            If no reply arrives within the timeout.
+        ConnectionClosedError
+            If the WebSocket is not connected.
         """
         if not self.connected:
             raise ConnectionClosedError("WebSocket is not connected")
@@ -239,7 +268,17 @@ class WebSocketClient:
     ) -> int:
         """Subscribe to Home Assistant events.
 
-        Returns the subscription id (needed for :meth:`unsubscribe`).
+        Parameters
+        ----------
+        handler : callable
+            Callback invoked with the event dict. May be sync or async.
+        event_type : str or None, optional
+            Event type to filter on. If ``None``, all events are received.
+
+        Returns
+        -------
+        int
+            The subscription id (needed for `unsubscribe`).
         """
         payload: dict[str, Any] = {"type": "subscribe_events"}
         if event_type is not None:
@@ -264,7 +303,13 @@ class WebSocketClient:
         return cmd_id
 
     async def unsubscribe(self, subscription_id: int) -> None:
-        """Unsubscribe a previously registered subscription."""
+        """Unsubscribe a previously registered subscription.
+
+        Parameters
+        ----------
+        subscription_id : int
+            The id returned by `subscribe_events`.
+        """
         await self.send_command({"type": "unsubscribe_events", "subscription": subscription_id})
         self._subscriptions.pop(subscription_id, None)
         for k, (sid, _handler) in list(self._event_subs.items()):
@@ -398,6 +443,18 @@ class WebSocketClient:
 
         Home Assistant replies with ``{"type": "pong"}`` rather than a
         ``result`` frame, so this is implemented as a separate code path.
+
+        Parameters
+        ----------
+        timeout : float or None, optional
+            Seconds to wait for the pong. Falls back to *request_timeout*.
+
+        Raises
+        ------
+        TimeoutError
+            If the pong does not arrive within the timeout.
+        ConnectionClosedError
+            If the WebSocket is not connected.
         """
         if not self.connected:
             raise ConnectionClosedError("WebSocket is not connected")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from .fake_ha import FakeHA
 
 @pytest_asyncio.fixture
 async def fake_ha() -> AsyncIterator[FakeHA]:
-    """Start a :class:`FakeHA` server and tear it down after the test."""
+    """Start a `FakeHA` server and tear it down after the test."""
     server = FakeHA()
     await server.start()
     try:
@@ -25,7 +25,7 @@ async def fake_ha() -> AsyncIterator[FakeHA]:
 
 @pytest_asyncio.fixture
 async def client(fake_ha: FakeHA) -> AsyncIterator[HAClient]:
-    """Return a connected :class:`HAClient` talking to the fake server."""
+    """Return a connected `HAClient` talking to the fake server."""
     ha = HAClient(
         fake_ha.base_url,
         token=fake_ha.token,

--- a/tests/fake_ha.py
+++ b/tests/fake_ha.py
@@ -1,11 +1,11 @@
 """A minimal in-process fake of the Home Assistant HTTP + WebSocket API.
 
-The fake is implemented with :mod:`aiohttp` so the production client exercises
+The fake is implemented with ``aiohttp`` so the production client exercises
 its real code paths (TCP sockets, JSON framing, auth handshake, etc.) against
 a deterministic server, without requiring a running Home Assistant instance.
 
-Only the surface area actually used by :mod:`haclient` is implemented. The
-fake is intentionally explicit – test cases can set ``server.handler`` to
+Only the surface area actually used by ``haclient`` is implemented. The
+fake is intentionally explicit -- test cases can set ``server.handler`` to
 override command behaviour or push arbitrary events.
 """
 
@@ -201,10 +201,17 @@ class FakeHA:
         )
 
     async def push_event(self, event_type: str, event: dict[str, Any]) -> None:
-        """Push an ``event`` to every WS currently subscribed to ``event_type``.
+        """Push an event to every WS currently subscribed to *event_type*.
 
         Each event is wrapped in the standard ``{"type": "event", "event": ...}``
-        envelope expected by :class:`haclient.websocket.WebSocketClient`.
+        envelope expected by `WebSocketClient`.
+
+        Parameters
+        ----------
+        event_type : str
+            The event type string (e.g. ``"state_changed"``).
+        event : dict
+            The event payload.
         """
         for ws in self.connections:
             if ws.closed:
@@ -225,7 +232,17 @@ class FakeHA:
         new_state: dict[str, Any] | None,
         old_state: dict[str, Any] | None = None,
     ) -> None:
-        """Convenience helper for pushing a ``state_changed`` event."""
+        """Push a ``state_changed`` event.
+
+        Parameters
+        ----------
+        entity_id : str
+            The entity whose state changed.
+        new_state : dict or None
+            The new state object.
+        old_state : dict or None, optional
+            The previous state object.
+        """
         await self.push_event(
             "state_changed",
             {


### PR DESCRIPTION
## Summary

- Convert all Python docstrings across 15 files to NumPy docstring style, compatible with `mkdocstrings` using `docstring_style: numpy`
- Replace Sphinx field-list syntax (`:class:`, `:meth:`, `:mod:`, `:func:`, `:attr:`) with plain backtick references
- Add formal `Parameters`, `Returns`, `Raises`, and `Attributes` sections to all public classes, methods, and functions
- Preserve concise one-liners for trivial methods with no parameters to document

## Files changed (15)

**Source (13):** `__init__.py`, `client.py`, `sync.py`, `rest.py`, `websocket.py`, `entity.py`, `registry.py`, `exceptions.py`, `domains/__init__.py`, `domains/light.py`, `domains/climate.py`, `domains/cover.py`, `domains/media_player.py`

**Tests (2):** `tests/conftest.py`, `tests/fake_ha.py`

## Verification

- All 129 tests pass
- Coverage: 95.12% (above 95% threshold)
- Ruff lint: all checks passed
- Ruff format: all files already formatted
- mypy strict: no issues found

## Notes

- No runtime behavior changes
- No behavior was invented -- documentation was only added where behavior is clear from the code
- All public objects now have consistent NumPy-style docstrings
- The following trivial domain methods (e.g. `Switch.turn_on`, `Cover.open`, `MediaPlayer.play`) retain concise one-liners since they take no meaningful parameters