### PR TITLE
Add MkDocs documentation with mkdocstrings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+# HaClient
+
+Async-first, high-level Python client for Home Assistant with REST and WebSocket support.
+
+## Features
+
+- Async context manager with automatic WebSocket connection and state priming
+- Typed domain accessors: light, switch, climate, cover, sensor, binary sensor, media player
+- Real-time state change listeners with granular filtering
+- Synchronous blocking wrapper for scripts, REPL, and Jupyter
+- Automatic WebSocket reconnection with exponential backoff
+- Fully typed (PEP 561) with strict mypy enforcement
+
+## Installation
+
+```bash
+pip install haclient
+```
+
+Or install from source:
+
+```bash
+git clone https://github.com/graphras-com/HaClient.git
+cd HaClient
+pip install .
+```
+
+## Quick Start
+
+### Async
+
+```python
+from haclient import HAClient
+
+async with HAClient("http://localhost:8123", token="YOUR_TOKEN") as ha:
+    light = ha.light("kitchen")
+    await light.turn_on(brightness=200)
+```
+
+### Synchronous
+
+```python
+from haclient import SyncHAClient
+
+with SyncHAClient("http://localhost:8123", token="YOUR_TOKEN") as ha:
+    light = ha.light("kitchen")
+    light.turn_on(brightness=200)
+```

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -1,0 +1,3 @@
+# Client
+
+::: haclient.client

--- a/docs/reference/domains/binary_sensor.md
+++ b/docs/reference/domains/binary_sensor.md
@@ -1,0 +1,3 @@
+# Binary Sensor
+
+::: haclient.domains.binary_sensor

--- a/docs/reference/domains/climate.md
+++ b/docs/reference/domains/climate.md
@@ -1,0 +1,3 @@
+# Climate
+
+::: haclient.domains.climate

--- a/docs/reference/domains/cover.md
+++ b/docs/reference/domains/cover.md
@@ -1,0 +1,3 @@
+# Cover
+
+::: haclient.domains.cover

--- a/docs/reference/domains/light.md
+++ b/docs/reference/domains/light.md
@@ -1,0 +1,3 @@
+# Light
+
+::: haclient.domains.light

--- a/docs/reference/domains/media_player.md
+++ b/docs/reference/domains/media_player.md
@@ -1,0 +1,3 @@
+# Media Player
+
+::: haclient.domains.media_player

--- a/docs/reference/domains/sensor.md
+++ b/docs/reference/domains/sensor.md
@@ -1,0 +1,3 @@
+# Sensor
+
+::: haclient.domains.sensor

--- a/docs/reference/domains/switch.md
+++ b/docs/reference/domains/switch.md
@@ -1,0 +1,3 @@
+# Switch
+
+::: haclient.domains.switch

--- a/docs/reference/entity.md
+++ b/docs/reference/entity.md
@@ -1,0 +1,3 @@
+# Entity
+
+::: haclient.entity

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -1,0 +1,3 @@
+# Exceptions
+
+::: haclient.exceptions

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,6 @@
+# API Reference
+
+::: haclient
+    options:
+      show_submodules: false
+      members: false

--- a/docs/reference/registry.md
+++ b/docs/reference/registry.md
@@ -1,0 +1,3 @@
+# Entity Registry
+
+::: haclient.registry

--- a/docs/reference/rest.md
+++ b/docs/reference/rest.md
@@ -1,0 +1,3 @@
+# REST
+
+::: haclient.rest

--- a/docs/reference/sync.md
+++ b/docs/reference/sync.md
@@ -1,0 +1,3 @@
+# Sync Client
+
+::: haclient.sync

--- a/docs/reference/websocket.md
+++ b/docs/reference/websocket.md
@@ -1,0 +1,3 @@
+# WebSocket
+
+::: haclient.websocket

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,52 @@
+site_name: HaClient
+site_description: Async-first, high-level Python client for Home Assistant
+repo_url: https://github.com/graphras-com/HaClient
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - API Reference:
+      - Overview: reference/index.md
+      - Client: reference/client.md
+      - Sync Client: reference/sync.md
+      - REST: reference/rest.md
+      - WebSocket: reference/websocket.md
+      - Entity: reference/entity.md
+      - Registry: reference/registry.md
+      - Exceptions: reference/exceptions.md
+      - Domains:
+          - Light: reference/domains/light.md
+          - Switch: reference/domains/switch.md
+          - Climate: reference/domains/climate.md
+          - Cover: reference/domains/cover.md
+          - Sensor: reference/domains/sensor.md
+          - Binary Sensor: reference/domains/binary_sensor.md
+          - Media Player: reference/domains/media_player.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: ["src"]
+          options:
+            docstring_style: numpy
+            show_source: true
+            show_signature_annotations: true
+            separate_signature: true
+            members_order: source
+            show_root_heading: true
+            show_root_full_path: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dev = [
   "ruff>=0.6",
   "mypy>=1.10",
 ]
+docs = [
+  "mkdocs>=1.6",
+  "mkdocs-material>=9.5",
+  "mkdocstrings[python]>=0.25",
+]
 
 [project.urls]
 Homepage = "https://github.com/graphras-com/HaClient"


### PR DESCRIPTION
## Summary

- Set up MkDocs with Material theme and mkdocstrings[python] for auto-generated API docs from NumPy-style docstrings
- Added `docs` optional dependency group to `pyproject.toml` (`mkdocs`, `mkdocs-material`, `mkdocstrings[python]`)
- API reference organized per-module: client, sync, rest, websocket, entity, registry, exceptions, and all domain accessors

## Files

- `mkdocs.yml` — site config with Material theme, search, and mkdocstrings plugin (`paths: ["src"]`, `docstring_style: numpy`)
- `docs/index.md` — landing page with project overview and quick start
- `docs/reference/` — one page per module/domain for granular API navigation
- `pyproject.toml` — added `[project.optional-dependencies] docs`

## Validation

- `mkdocs build --strict` passes with no warnings
- All 129 tests pass, coverage 95.12%

## Usage

```bash
pip install -e ".[docs]"
mkdocs serve
```