### PR TITLE
Add GitHub Pages docs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[docs]"
+      - run: mkdocs build --strict
+      - if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.9",
-  "pydoc-markdown>=4.8.2",
-  "tool>=0.8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docs.yml` that builds docs with `mkdocs build --strict` on PRs (validation gate) and deploys to GitHub Pages on push to main using `actions/deploy-pages`
- Remove spurious `pydoc-markdown` and `tool` from runtime dependencies (only `aiohttp` should be a runtime dep)

## Setup required

After merging, enable GitHub Pages in repo settings:
**Settings → Pages → Source → GitHub Actions**