### PR TITLE
feat: add Timer domain for Home Assistant timer entities

### DIFF
--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from .domains.media_player import MediaPlayer
     from .domains.sensor import Sensor
     from .domains.switch import Switch
+    from .domains.timer import Timer
 
 _E = TypeVar("_E", bound=Entity)
 
@@ -381,3 +382,20 @@ class HAClient:
         from .domains.binary_sensor import BinarySensor as _BinarySensor
 
         return self._get_or_create("binary_sensor", name, _BinarySensor)
+
+    def timer(self, name: str) -> Timer:
+        """Return the `Timer` for *name*, creating it if needed.
+
+        Parameters
+        ----------
+        name : str
+            Short object-id or fully-qualified entity id.
+
+        Returns
+        -------
+        Timer
+            The timer entity.
+        """
+        from .domains.timer import Timer as _Timer
+
+        return self._get_or_create("timer", name, _Timer)

--- a/src/haclient/domains/__init__.py
+++ b/src/haclient/domains/__init__.py
@@ -7,6 +7,7 @@ from .light import Light
 from .media_player import FavoriteItem, MediaPlayer, NowPlaying
 from .sensor import Sensor
 from .switch import Switch
+from .timer import Timer
 
 __all__ = [
     "BinarySensor",
@@ -18,4 +19,5 @@ __all__ = [
     "NowPlaying",
     "Sensor",
     "Switch",
+    "Timer",
 ]

--- a/src/haclient/domains/timer.py
+++ b/src/haclient/domains/timer.py
@@ -1,0 +1,109 @@
+"""``timer`` domain implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..entity import Entity
+
+
+class Timer(Entity):
+    """A Home Assistant timer entity.
+
+    Timer states: ``idle``, ``active``, ``paused``.
+    """
+
+    domain = "timer"
+
+    # -- State properties --
+
+    @property
+    def is_active(self) -> bool:
+        """``True`` if the timer is currently running."""
+        return self.state == "active"
+
+    @property
+    def is_paused(self) -> bool:
+        """``True`` if the timer is paused."""
+        return self.state == "paused"
+
+    @property
+    def is_idle(self) -> bool:
+        """``True`` if the timer is idle (not started or finished)."""
+        return self.state == "idle"
+
+    @property
+    def duration(self) -> str | None:
+        """Configured duration (e.g. ``"0:05:00"``)."""
+        val = self.attributes.get("duration")
+        return str(val) if val is not None else None
+
+    @property
+    def remaining(self) -> str | None:
+        """Time remaining (e.g. ``"0:04:30"``)."""
+        val = self.attributes.get("remaining")
+        return str(val) if val is not None else None
+
+    @property
+    def finishes_at(self) -> str | None:
+        """ISO-8601 datetime when the timer will finish, if active."""
+        val = self.attributes.get("finishes_at")
+        return str(val) if val is not None else None
+
+    # -- Actions --
+
+    async def start(self, *, duration: str | None = None) -> None:
+        """Start (or restart) the timer.
+
+        Parameters
+        ----------
+        duration : str or None, optional
+            Override duration (e.g. ``"00:05:00"``).
+        """
+        data: dict[str, Any] | None = {"duration": duration} if duration else None
+        await self.call_service("start", data)
+
+    async def pause(self) -> None:
+        """Pause the timer."""
+        await self.call_service("pause")
+
+    async def cancel(self) -> None:
+        """Cancel the timer (returns to idle)."""
+        await self.call_service("cancel")
+
+    async def finish(self) -> None:
+        """Finish the timer immediately."""
+        await self.call_service("finish")
+
+    async def change(self, *, duration: str) -> None:
+        """Add or subtract time from a running timer.
+
+        Parameters
+        ----------
+        duration : str
+            Duration to add/subtract (e.g. ``"00:01:00"`` or ``"-00:00:30"``).
+        """
+        await self.call_service("change", {"duration": duration})
+
+    # -- Listener decorators --
+
+    def on_start(self, func: Any) -> Any:
+        """Register a listener for when the timer starts (becomes active).
+
+        Callback: ``(old_state, new_state)``.
+        """
+        return self._register_state_transition_listener("active", func)
+
+    def on_pause(self, func: Any) -> Any:
+        """Register a listener for when the timer is paused.
+
+        Callback: ``(old_state, new_state)``.
+        """
+        return self._register_state_transition_listener("paused", func)
+
+    def on_idle(self, func: Any) -> Any:
+        """Register a listener for when the timer becomes idle (finished or cancelled).
+
+        Callback: ``(old_state, new_state)``.
+        """
+        return self._register_state_transition_listener("idle", func)

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -251,3 +251,70 @@ async def test_entity_refresh_missing(client: HAClient) -> None:
     light = client.light("missing")
     await light.async_refresh()
     assert light.state == "unavailable"
+
+
+async def test_timer_actions(client: HAClient, fake_ha: FakeHA) -> None:
+    t = client.timer("my_timer")
+    await t.start()
+    await t.start(duration="00:05:00")
+    await t.pause()
+    await t.cancel()
+    await t.finish()
+    await t.change(duration="00:01:00")
+    assert [c["service"] for c in fake_ha.ws_service_calls] == [
+        "start",
+        "start",
+        "pause",
+        "cancel",
+        "finish",
+        "change",
+    ]
+    # First start has no extra service_data beyond entity_id
+    assert "duration" not in fake_ha.ws_service_calls[0].get("service_data", {})
+    # Second start carries duration
+    assert fake_ha.ws_service_calls[1]["service_data"]["duration"] == "00:05:00"
+    # Change carries duration
+    assert fake_ha.ws_service_calls[5]["service_data"]["duration"] == "00:01:00"
+
+
+async def test_timer_state_properties() -> None:
+    ha = HAClient("http://x", "t")
+    try:
+        t = ha.timer("my_timer")
+        t._apply_state(
+            {
+                "state": "active",
+                "attributes": {
+                    "duration": "0:05:00",
+                    "remaining": "0:04:30",
+                    "finishes_at": "2024-01-01T12:05:00+00:00",
+                },
+            }
+        )
+        assert t.is_active
+        assert not t.is_paused
+        assert not t.is_idle
+        assert t.duration == "0:05:00"
+        assert t.remaining == "0:04:30"
+        assert t.finishes_at == "2024-01-01T12:05:00+00:00"
+
+        t._apply_state(
+            {
+                "state": "paused",
+                "attributes": {"duration": "0:05:00", "remaining": "0:03:00"},
+            }
+        )
+        assert not t.is_active
+        assert t.is_paused
+        assert not t.is_idle
+        assert t.remaining == "0:03:00"
+        assert t.finishes_at is None
+
+        t._apply_state({"state": "idle", "attributes": {"duration": "0:05:00"}})
+        assert not t.is_active
+        assert not t.is_paused
+        assert t.is_idle
+        assert t.remaining is None
+        assert t.finishes_at is None
+    finally:
+        await ha.close()


### PR DESCRIPTION
## Summary

- Add `Timer` domain class (`src/haclient/domains/timer.py`) supporting HA timer entities (`timer.<name>`)
- Properties: `is_active`, `is_paused`, `is_idle`, `duration`, `remaining`, `finishes_at`
- Actions: `start(duration=)`, `pause()`, `cancel()`, `finish()`, `change(duration=)`
- Listener decorators: `on_start()`, `on_pause()`, `on_idle()`
- Register `timer()` accessor on `HAClient`

## Usage

```python
async with HAClient("http://ha:8123", token="...") as ha:
    t = ha.timer("my_timer")
    await t.start(duration="00:05:00")
    
    @t.on_idle
    def finished(old, new):
        print("Timer done!")
```

All 131 tests pass. Coverage: 95.07%.