### PR TITLE
docs: add Timer domain to mkdocs reference

### DIFF
--- a/docs/reference/domains/timer.md
+++ b/docs/reference/domains/timer.md
@@ -1,0 +1,3 @@
+# Timer
+
+::: haclient.domains.timer

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
           - Sensor: reference/domains/sensor.md
           - Binary Sensor: reference/domains/binary_sensor.md
           - Media Player: reference/domains/media_player.md
+          - Timer: reference/domains/timer.md
 
 plugins:
   - search


### PR DESCRIPTION
## Summary
- Add missing Timer domain reference page (`docs/reference/domains/timer.md`)
- Add Timer nav entry to `mkdocs.yml` under Domains