### PR TITLE
feat: ephemeral timers with auto-cleanup and optional naming

### DIFF
--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -429,19 +429,48 @@ class HAClient:
 
         return self._get_or_create("scene", name, _Scene)
 
-    def timer(self, name: str) -> Timer:
-        """Return the `Timer` for *name*, creating it if needed.
+    def timer(self, name: str | None = None, *, persistent: bool = False) -> Timer:
+        """Return a `Timer`, creating the Python object if needed.
+
+        Timers are **ephemeral by default**: the HA helper is created on the
+        first action and deleted automatically when the timer returns to idle.
+        Pass ``persistent=True`` to keep the helper alive.
 
         Parameters
         ----------
-        name : str
-            Short object-id or fully-qualified entity id.
+        name : str or None, optional
+            Short object-id or fully-qualified entity id.  When ``None``
+            a unique id is generated automatically (only allowed for
+            ephemeral timers).
+        persistent : bool, optional
+            If ``True``, the HA helper is **not** deleted on idle.
+            Requires an explicit *name*.
 
         Returns
         -------
         Timer
             The timer entity.
+
+        Raises
+        ------
+        ValueError
+            If ``persistent=True`` and *name* is ``None``.
         """
         from .domains.timer import Timer as _Timer
+        from .domains.timer import _generate_timer_id
 
-        return self._get_or_create("timer", name, _Timer)
+        if name is None:
+            if persistent:
+                raise ValueError("Persistent timers require an explicit name")
+            name = _generate_timer_id()
+
+        entity_id = self.registry.resolve("timer", name)
+        existing = self.registry.get(entity_id)
+        if existing is not None:
+            if not isinstance(existing, _Timer):
+                raise HAClientError(
+                    f"Entity {entity_id} is registered as {type(existing).__name__}, "
+                    f"not {_Timer.__name__}"
+                )
+            return existing
+        return _Timer(entity_id, self, persistent=persistent)

--- a/src/haclient/domains/timer.py
+++ b/src/haclient/domains/timer.py
@@ -4,11 +4,23 @@ from __future__ import annotations
 
 import datetime
 import logging
+import uuid
 from typing import Any
 
 from ..entity import Entity, ValueChangeHandler
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _generate_timer_id() -> str:
+    """Generate a short unique object-id for an ephemeral timer.
+
+    Returns
+    -------
+    str
+        A string like ``"haclient_a1b2c3d4"``.
+    """
+    return f"haclient_{uuid.uuid4().hex[:8]}"
 
 
 class Timer(Entity):
@@ -18,11 +30,14 @@ class Timer(Entity):
     Actions use intent-specific names: ``start``, ``pause``, ``cancel``,
     ``finish``, ``change``.
 
-    If the timer helper does not yet exist in Home Assistant, it is created
-    automatically via the ``timer/create`` WebSocket command the first time
-    an action method (``start``, ``pause``, etc.) is called.  This means
-    users never need to pre-create timer helpers — the library handles it
-    transparently.
+    Timers are **ephemeral by default**: the HA helper is created
+    automatically on the first action and deleted when the timer returns
+    to idle (natural finish or cancellation).  The same ``Timer`` object
+    can be restarted afterwards — the helper is transparently re-created.
+
+    Pass ``persistent=True`` to keep the HA helper alive after the timer
+    finishes.  Persistent timers require an explicit *name*; ephemeral
+    timers auto-generate one when no name is provided.
 
     In addition to the generic ``on_idle`` listener (which fires for both
     natural expiry and explicit cancellation), the timer provides
@@ -33,15 +48,37 @@ class Timer(Entity):
     The ``time_remaining`` property computes the live seconds remaining
     from ``finishes_at`` when the timer is active, or parses the
     ``remaining`` attribute when paused.
+
+    Parameters
+    ----------
+    entity_id : str
+        Fully-qualified entity id (e.g. ``"timer.my_timer"``).
+    client : HAClient
+        The owning client instance.
+    persistent : bool, optional
+        If ``False`` (default), the HA helper is deleted automatically
+        when the timer returns to idle.
     """
 
     domain = "timer"
 
-    def __init__(self, entity_id: str, client: Any) -> None:
+    def __init__(self, entity_id: str, client: Any, *, persistent: bool = False) -> None:
         super().__init__(entity_id, client)
         self._finished_listeners: list[ValueChangeHandler] = []
         self._cancelled_listeners: list[ValueChangeHandler] = []
         self._ensured: bool = False
+        self._persistent: bool = persistent
+
+    @property
+    def persistent(self) -> bool:
+        """Whether this timer keeps its HA helper after returning to idle.
+
+        Returns
+        -------
+        bool
+            ``True`` if the timer is persistent.
+        """
+        return self._persistent
 
     # -- State properties --
 
@@ -149,6 +186,46 @@ class Timer(Entity):
         return None
 
     # -- Lifecycle --
+
+    def _handle_state_changed(
+        self,
+        old_state: dict[str, Any] | None,
+        new_state: dict[str, Any] | None,
+    ) -> None:
+        """Update state, dispatch listeners, then auto-delete if ephemeral.
+
+        For non-persistent timers, the HA helper is deleted when the timer
+        transitions to ``idle``.  The cleanup runs *after* all user listeners
+        have been dispatched so that callbacks see the final state.
+
+        Parameters
+        ----------
+        old_state : dict or None
+            The previous state object.
+        new_state : dict or None
+            The new state object.
+        """
+        old_state_str = (old_state or {}).get("state")
+        super()._handle_state_changed(old_state, new_state)
+
+        if (
+            not self._persistent
+            and self.state == "idle"
+            and old_state_str is not None
+            and old_state_str != "idle"
+        ):
+            self._schedule_value(self._auto_cleanup, old_state_str, self.state)
+
+    async def _auto_cleanup(self, _old: Any, _new: Any) -> None:
+        """Delete the HA helper and reset internal state for re-creation.
+
+        This is scheduled as a task after user listeners have been invoked.
+        """
+        try:
+            await self.delete()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Auto-cleanup of %s failed", self.entity_id, exc_info=True)
+        self.state = "unknown"
 
     async def _ensure_exists(self) -> None:
         """Create the timer helper in Home Assistant if it does not exist.

--- a/src/haclient/domains/timer.py
+++ b/src/haclient/domains/timer.py
@@ -39,6 +39,10 @@ class Timer(Entity):
     finishes.  Persistent timers require an explicit *name*; ephemeral
     timers auto-generate one when no name is provided.
 
+    Timers that already exist in Home Assistant (e.g. created via the UI)
+    are never auto-deleted, regardless of the ``persistent`` flag.  Only
+    helpers created by the library are eligible for auto-cleanup.
+
     In addition to the generic ``on_idle`` listener (which fires for both
     natural expiry and explicit cancellation), the timer provides
     ``on_finished`` and ``on_cancelled`` listeners that fire only for the
@@ -68,6 +72,7 @@ class Timer(Entity):
         self._cancelled_listeners: list[ValueChangeHandler] = []
         self._ensured: bool = False
         self._persistent: bool = persistent
+        self._created_by_us: bool = False
 
     @property
     def persistent(self) -> bool:
@@ -194,9 +199,13 @@ class Timer(Entity):
     ) -> None:
         """Update state, dispatch listeners, then auto-delete if ephemeral.
 
-        For non-persistent timers, the HA helper is deleted when the timer
-        transitions to ``idle``.  The cleanup runs *after* all user listeners
-        have been dispatched so that callbacks see the final state.
+        For non-persistent timers **that were created by the library**, the
+        HA helper is deleted when the timer transitions to ``idle``.  Timers
+        that already existed in Home Assistant (e.g. created via the UI) are
+        never auto-deleted, even when ``persistent`` is ``False``.
+
+        The cleanup runs *after* all user listeners have been dispatched so
+        that callbacks see the final state.
 
         Parameters
         ----------
@@ -210,6 +219,7 @@ class Timer(Entity):
 
         if (
             not self._persistent
+            and self._created_by_us
             and self.state == "idle"
             and old_state_str is not None
             and old_state_str != "idle"
@@ -226,6 +236,7 @@ class Timer(Entity):
         except Exception:  # noqa: BLE001
             _LOGGER.debug("Auto-cleanup of %s failed", self.entity_id, exc_info=True)
         self.state = "unknown"
+        self._created_by_us = False
 
     async def _ensure_exists(self) -> None:
         """Create the timer helper in Home Assistant if it does not exist.
@@ -248,6 +259,7 @@ class Timer(Entity):
             }
         )
         self._ensured = True
+        self._created_by_us = True
 
     async def delete(self) -> None:
         """Delete the timer helper from Home Assistant.
@@ -269,6 +281,7 @@ class Timer(Entity):
             }
         )
         self._ensured = False
+        self._created_by_us = False
 
     # -- Actions --
 

--- a/tests/test_timer_lifecycle.py
+++ b/tests/test_timer_lifecycle.py
@@ -241,6 +241,54 @@ async def test_persistent_requires_name(client: HAClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Pre-existing HA timers (not created by us)
+# ---------------------------------------------------------------------------
+
+
+async def test_preexisting_timer_not_auto_deleted(client: HAClient, fake_ha: FakeHA) -> None:
+    """A timer that already exists in HA must not be auto-deleted on idle."""
+    t = client.timer("existing_timer")
+    # Simulate HA reporting the timer during initial state fetch.
+    t._apply_state({"state": "idle", "attributes": {"duration": "0:05:00"}})
+    assert t.state == "idle"
+    assert t._created_by_us is False
+
+    # Start it (no timer/create because state is already known).
+    await t.start(duration="00:00:05")
+
+    # Simulate active -> idle.
+    await fake_ha.push_state_changed(
+        "timer.existing_timer",
+        {"state": "idle", "attributes": {}},
+        {"state": "active", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
+
+    # State should update normally but no auto-delete.
+    assert t.state == "idle"
+    assert t._created_by_us is False
+
+
+async def test_library_created_timer_auto_deletes(client: HAClient, fake_ha: FakeHA) -> None:
+    """A timer created by the library (via _ensure_exists) does auto-delete."""
+    t = client.timer("lib_timer")
+    assert t.state == "unknown"
+
+    await t.start(duration="00:00:05")
+    assert t._created_by_us is True
+
+    await fake_ha.push_state_changed(
+        "timer.lib_timer",
+        {"state": "idle", "attributes": {}},
+        {"state": "active", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
+
+    assert t.state == "unknown"
+    assert t._created_by_us is False
+
+
+# ---------------------------------------------------------------------------
 # Auto-generated names (unnamed ephemeral timers)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_timer_lifecycle.py
+++ b/tests/test_timer_lifecycle.py
@@ -1,10 +1,18 @@
-"""Tests for Timer auto-create and delete lifecycle."""
+"""Tests for Timer auto-create, delete, ephemeral and persistent lifecycle."""
 
 from __future__ import annotations
+
+import asyncio
+
+import pytest
 
 from haclient import HAClient
 
 from .fake_ha import FakeHA
+
+# ---------------------------------------------------------------------------
+# Auto-create (unchanged behaviour)
+# ---------------------------------------------------------------------------
 
 
 async def test_timer_start_auto_creates_when_unknown(client: HAClient, fake_ha: FakeHA) -> None:
@@ -14,9 +22,6 @@ async def test_timer_start_auto_creates_when_unknown(client: HAClient, fake_ha: 
 
     await t.start(duration="00:00:10")
 
-    # The timer/create command should have been sent (check ws_service_calls
-    # won't capture it — we need to check via the call_service call that followed).
-    # The call_service for timer.start should be present.
     assert len(fake_ha.ws_service_calls) == 1
     call = fake_ha.ws_service_calls[0]
     assert call["domain"] == "timer"
@@ -27,13 +32,11 @@ async def test_timer_start_auto_creates_when_unknown(client: HAClient, fake_ha: 
 async def test_timer_start_skips_create_when_state_known(client: HAClient, fake_ha: FakeHA) -> None:
     """If the timer already has a state from HA, _ensure_exists is a no-op."""
     t = client.timer("my_timer")
-    # Simulate that HA already reported the entity's state.
     t._apply_state({"state": "idle", "attributes": {"duration": "0:01:00"}})
     assert t.state == "idle"
 
     await t.start(duration="00:00:10")
 
-    # Only the service call, no timer/create.
     assert len(fake_ha.ws_service_calls) == 1
     call = fake_ha.ws_service_calls[0]
     assert call["domain"] == "timer"
@@ -48,7 +51,6 @@ async def test_timer_ensure_exists_only_called_once(client: HAClient, fake_ha: F
     await t.start(duration="00:00:10")
     await t.pause()
 
-    # Both actions should fire, but timer/create only once.
     assert len(fake_ha.ws_service_calls) == 2
     assert t._ensured is True
 
@@ -85,7 +87,6 @@ async def test_timer_change_auto_creates(client: HAClient, fake_ha: FakeHA) -> N
 async def test_timer_delete(client: HAClient, fake_ha: FakeHA) -> None:
     """delete() sends timer/delete and resets _ensured."""
     t = client.timer("my_timer")
-    # First ensure it exists.
     await t.start()
     assert t._ensured is True
 
@@ -102,7 +103,225 @@ async def test_timer_delete_then_start_recreates(client: HAClient, fake_ha: Fake
     await t.delete()
     assert t._ensured is False
 
-    # Reset state to unknown to simulate the entity being gone.
     t.state = "unknown"
     await t.start()
     assert t._ensured is True
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral timers (default)
+# ---------------------------------------------------------------------------
+
+
+async def test_ephemeral_timer_is_default(client: HAClient) -> None:
+    """Timers are ephemeral by default."""
+    t = client.timer("my_timer")
+    assert t.persistent is False
+
+
+async def test_ephemeral_auto_deletes_on_idle(client: HAClient, fake_ha: FakeHA) -> None:
+    """An ephemeral timer auto-deletes its HA helper when it transitions to idle."""
+    t = client.timer("my_timer")
+    await t.start(duration="00:00:05")
+
+    # Simulate HA reporting active -> idle (timer finished).
+    await fake_ha.push_state_changed(
+        "timer.my_timer",
+        {"state": "idle", "attributes": {}},
+        {"state": "active", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
+
+    assert t.state == "unknown"
+    assert t._ensured is False
+
+
+async def test_ephemeral_user_on_idle_fires_before_cleanup(
+    client: HAClient, fake_ha: FakeHA
+) -> None:
+    """User on_idle listeners fire even though the timer is ephemeral."""
+    t = client.timer("my_timer")
+    captured: list[tuple[str | None, str | None]] = []
+
+    @t.on_idle
+    def handler(old: str | None, new: str | None) -> None:
+        captured.append((old, new))
+
+    await t.start(duration="00:00:05")
+
+    await fake_ha.push_state_changed(
+        "timer.my_timer",
+        {"state": "idle", "attributes": {}},
+        {"state": "active", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
+
+    assert captured == [("active", "idle")]
+
+
+async def test_ephemeral_can_restart_after_auto_delete(client: HAClient, fake_ha: FakeHA) -> None:
+    """After auto-delete, calling start() re-creates the timer transparently."""
+    t = client.timer("my_timer")
+    await t.start(duration="00:00:05")
+
+    # Trigger auto-delete.
+    await fake_ha.push_state_changed(
+        "timer.my_timer",
+        {"state": "idle", "attributes": {}},
+        {"state": "active", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
+    assert t._ensured is False
+    assert t.state == "unknown"
+
+    # Restart — should re-create.
+    await t.start(duration="00:00:10")
+    assert t._ensured is True
+
+
+async def test_ephemeral_no_cleanup_on_idle_to_idle(client: HAClient, fake_ha: FakeHA) -> None:
+    """No auto-delete when old_state is already idle (avoid spurious deletes)."""
+    t = client.timer("my_timer")
+    t._ensured = True
+
+    # idle -> idle should not trigger cleanup.
+    await fake_ha.push_state_changed(
+        "timer.my_timer",
+        {"state": "idle", "attributes": {}},
+        {"state": "idle", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
+
+    # _ensured should remain True — no cleanup was triggered.
+    assert t._ensured is True
+
+
+async def test_ephemeral_no_cleanup_when_old_state_none(client: HAClient, fake_ha: FakeHA) -> None:
+    """No auto-delete when old_state is None (initial state load)."""
+    t = client.timer("my_timer")
+    t._ensured = True
+
+    await fake_ha.push_state_changed(
+        "timer.my_timer",
+        {"state": "idle", "attributes": {}},
+        None,
+    )
+    await asyncio.sleep(0.1)
+
+    assert t._ensured is True
+
+
+# ---------------------------------------------------------------------------
+# Persistent timers
+# ---------------------------------------------------------------------------
+
+
+async def test_persistent_timer_no_auto_delete(client: HAClient, fake_ha: FakeHA) -> None:
+    """A persistent timer does not auto-delete its HA helper on idle."""
+    t = client.timer("my_timer", persistent=True)
+    assert t.persistent is True
+    await t.start(duration="00:00:05")
+
+    await fake_ha.push_state_changed(
+        "timer.my_timer",
+        {"state": "idle", "attributes": {}},
+        {"state": "active", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
+
+    # State updated but _ensured not reset, state not reverted to unknown.
+    assert t.state == "idle"
+    assert t._ensured is True
+
+
+async def test_persistent_requires_name(client: HAClient) -> None:
+    """persistent=True without a name should raise ValueError."""
+    with pytest.raises(ValueError, match="Persistent timers require an explicit name"):
+        client.timer(persistent=True)
+
+
+# ---------------------------------------------------------------------------
+# Auto-generated names (unnamed ephemeral timers)
+# ---------------------------------------------------------------------------
+
+
+async def test_unnamed_ephemeral_generates_id(client: HAClient) -> None:
+    """Calling timer() without a name generates a unique entity id."""
+    t = client.timer()
+    assert t.entity_id.startswith("timer.haclient_")
+    assert len(t.entity_id) == len("timer.haclient_") + 8
+
+
+async def test_unnamed_ephemeral_unique_ids(client: HAClient) -> None:
+    """Each unnamed timer() call produces a different id."""
+    t1 = client.timer()
+    t2 = client.timer()
+    assert t1.entity_id != t2.entity_id
+
+
+async def test_named_ephemeral_uses_given_name(client: HAClient) -> None:
+    """Providing a name uses that name, not a generated one."""
+    t = client.timer("my_cooldown")
+    assert t.entity_id == "timer.my_cooldown"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+async def test_ephemeral_auto_cleanup_handles_delete_failure(
+    client: HAClient, fake_ha: FakeHA
+) -> None:
+    """If the delete WS command fails, _auto_cleanup logs but still resets state."""
+    from aiohttp import web
+
+    async def fail_delete(server: FakeHA, ws: web.WebSocketResponse, msg: dict) -> None:
+        await ws.send_json(
+            {
+                "id": msg["id"],
+                "type": "result",
+                "success": False,
+                "error": {"code": "not_found", "message": "Timer not found"},
+            }
+        )
+
+    fake_ha.handlers["timer/delete"] = fail_delete
+
+    t = client.timer("will_fail")
+    await t.start(duration="00:00:05")
+
+    await fake_ha.push_state_changed(
+        "timer.will_fail",
+        {"state": "idle", "attributes": {}},
+        {"state": "active", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
+
+    # Cleanup failed but state should still be reset.
+    assert t.state == "unknown"
+
+
+async def test_handle_timer_event_ignores_unknown_event_type(
+    client: HAClient, fake_ha: FakeHA
+) -> None:
+    """_handle_timer_event returns early for unrecognised event types."""
+    t = client.timer("my_timer")
+    captured: list[tuple] = []
+
+    @t.on_finished
+    def handler(eid: str, data: dict) -> None:
+        captured.append((eid, data))
+
+    # Push an event with a bogus type via the timer event handler directly.
+    t._handle_timer_event("timer.unknown_event", {"entity_id": "timer.my_timer"})
+    await asyncio.sleep(0.05)
+    assert captured == []
+
+
+async def test_parse_duration_invalid_format() -> None:
+    """_parse_duration_to_seconds returns None for non-HH:MM:SS strings."""
+    from haclient.domains.timer import _parse_duration_to_seconds
+
+    assert _parse_duration_to_seconds("invalid") is None
+    assert _parse_duration_to_seconds("abc:de:fg") is None


### PR DESCRIPTION
## Summary
- Timers are **ephemeral by default** — HA helper is auto-created on first action and auto-deleted when the timer returns to idle, preventing accumulation of unused helpers
- `client.timer()` without a name auto-generates a unique ID (`timer.haclient_a1b2c3d4`)
- `client.timer("name", persistent=True)` keeps the HA helper alive after idle (requires explicit name)
- Same Timer object can be restarted after auto-cleanup — helper is transparently re-created

## API Examples
```python
# Ephemeral (default) — auto-created, auto-deleted on idle
t = client.timer()
await t.start(duration="00:05:00")
# HA helper deleted when timer finishes

# Named ephemeral
t = client.timer("my_cooldown")

# Persistent — stays in HA
t = client.timer("kitchen_timer", persistent=True)
```

## Implementation
- `Timer._handle_state_changed` override schedules cleanup *after* all user listeners
- `_auto_cleanup` gracefully handles delete failures (logs + resets state)
- `persistent=True` without name raises `ValueError`
- 23 tests (179 total), timer.py at 100% coverage, overall 95.26%