### PR TITLE
Enforce short object-id only on domain accessors

### DIFF
--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -268,7 +268,8 @@ class HAClient:
         domain : str
             The Home Assistant domain (e.g. ``"light"``).
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"kitchen"``).  The domain prefix is
+            added automatically; do not pass a fully-qualified entity id.
         cls : type
             The ``Entity`` subclass to instantiate if absent.
 
@@ -299,7 +300,8 @@ class HAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
 
         Returns
         -------
@@ -316,7 +318,8 @@ class HAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
 
         Returns
         -------
@@ -333,7 +336,8 @@ class HAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
 
         Returns
         -------
@@ -350,7 +354,8 @@ class HAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
 
         Returns
         -------
@@ -367,7 +372,8 @@ class HAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
 
         Returns
         -------
@@ -384,7 +390,8 @@ class HAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
 
         Returns
         -------
@@ -401,7 +408,8 @@ class HAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
 
         Returns
         -------
@@ -418,7 +426,8 @@ class HAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
 
         Returns
         -------
@@ -506,9 +515,9 @@ class HAClient:
         Parameters
         ----------
         name : str or None, optional
-            Short object-id or fully-qualified entity id.  When ``None``
-            a unique id is generated automatically (only allowed for
-            ephemeral timers).
+            Short object-id (e.g. ``"my_timer"``).  The ``timer.`` prefix
+            is added automatically.  When ``None`` a unique id is
+            generated automatically (only allowed for ephemeral timers).
         persistent : bool, optional
             If ``True``, the HA helper is **not** deleted on idle.
             Requires an explicit *name*.

--- a/src/haclient/domains/timer.py
+++ b/src/haclient/domains/timer.py
@@ -57,6 +57,9 @@ class Timer(Entity):
     ----------
     entity_id : str
         Fully-qualified entity id (e.g. ``"timer.my_timer"``).
+        Users should obtain timers via ``client.timer("my_timer")``
+        which accepts the short object-id and prefixes it
+        automatically.
     client : HAClient
         The owning client instance.
     persistent : bool, optional

--- a/src/haclient/entity.py
+++ b/src/haclient/entity.py
@@ -34,10 +34,21 @@ class Entity:
     state known to the client. They are refreshed automatically when the
     client receives ``state_changed`` events for this entity.
 
+    .. note::
+
+        Users should obtain entities via the domain accessors on
+        `HAClient` (e.g. ``client.light("kitchen")``) which accept a
+        **short object-id** and prefix it automatically.  Direct
+        construction of ``Entity`` (or its subclasses) requires a
+        fully-qualified ``entity_id`` because the base class has no
+        domain context of its own.
+
     Parameters
     ----------
     entity_id : str
         Fully-qualified entity id (e.g. ``"light.kitchen"``).
+        When using domain accessors the prefix is added automatically;
+        direct construction must supply the full id.
     client : HAClient
         The owning client instance.
 

--- a/src/haclient/registry.py
+++ b/src/haclient/registry.py
@@ -78,25 +78,33 @@ class EntityRegistry:
         self._entities.clear()
 
     def resolve(self, domain: str, name: str) -> str:
-        """Resolve a short name to a full ``entity_id`` within *domain*.
-
-        *name* may be either the object id (``"livingroom"``) or the
-        fully-qualified ``entity_id`` (``"media_player.livingroom"``).
+        """Build a fully-qualified ``entity_id`` from *domain* and *name*.
 
         Parameters
         ----------
         domain : str
             The Home Assistant domain (e.g. ``"media_player"``).
         name : str
-            The short name or full entity id to resolve.
+            The short object-id (e.g. ``"livingroom"``).  Must **not**
+            contain a dot; pass the short name only, not the
+            fully-qualified entity id.
 
         Returns
         -------
         str
-            The fully-qualified entity id.
+            The fully-qualified entity id (``"{domain}.{name}"``).
+
+        Raises
+        ------
+        ValueError
+            If *name* contains a dot.
         """
         if "." in name:
-            return name
+            hint = name.split(".", 1)[1]
+            raise ValueError(
+                f"Pass the short object-id (e.g. {hint!r}), "
+                f"not the fully-qualified entity id {name!r}"
+            )
         return f"{domain}.{name}"
 
     def in_domain(self, domain: str) -> list[Entity]:

--- a/src/haclient/sync.py
+++ b/src/haclient/sync.py
@@ -180,7 +180,8 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.media_player(name), self._loop_thread)
 
@@ -190,7 +191,8 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.light(name), self._loop_thread)
 
@@ -200,7 +202,8 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.switch(name), self._loop_thread)
 
@@ -210,7 +213,8 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.climate(name), self._loop_thread)
 
@@ -220,7 +224,8 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.cover(name), self._loop_thread)
 
@@ -230,7 +235,8 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.sensor(name), self._loop_thread)
 
@@ -240,7 +246,8 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.binary_sensor(name), self._loop_thread)
 
@@ -250,7 +257,8 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.scene(name), self._loop_thread)
 
@@ -305,6 +313,7 @@ class SyncHAClient:
         Parameters
         ----------
         name : str
-            Short object-id or fully-qualified entity id.
+            Short object-id (e.g. ``"livingroom"``).  The domain prefix
+            is added automatically.
         """
         return _SyncProxy(self._client.timer(name), self._loop_thread)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -66,8 +66,11 @@ async def test_domain_accessor_reuse(client: HAClient) -> None:
     a = client.media_player("livingroom")
     b = client.media_player("livingroom")
     assert a is b
-    c = client.media_player("media_player.livingroom")
-    assert c is a
+
+
+async def test_domain_accessor_rejects_fully_qualified(client: HAClient) -> None:
+    with pytest.raises(ValueError, match="short object-id"):
+        client.media_player("media_player.livingroom")
 
 
 async def test_domain_accessor_type_conflict(client: HAClient) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -9,11 +9,17 @@ from haclient.exceptions import EntityNotFoundError
 from haclient.registry import EntityRegistry
 
 
-def test_resolve_short_and_full_name() -> None:
+def test_resolve_short_name() -> None:
     reg = EntityRegistry()
     assert reg.resolve("light", "kitchen") == "light.kitchen"
-    assert reg.resolve("light", "light.kitchen") == "light.kitchen"
-    assert reg.resolve("light", "switch.hall") == "switch.hall"
+
+
+def test_resolve_rejects_fully_qualified() -> None:
+    reg = EntityRegistry()
+    with pytest.raises(ValueError, match="short object-id"):
+        reg.resolve("light", "light.kitchen")
+    with pytest.raises(ValueError, match="short object-id"):
+        reg.resolve("light", "switch.hall")
 
 
 def test_require_missing() -> None:


### PR DESCRIPTION
## Summary

- **Breaking change:** `registry.resolve()` now raises `ValueError` if the name contains a dot, enforcing that domain accessors only accept short object-ids (e.g. `"kitchen"`, not `"light.kitchen"`)
- Updated all docstrings across `client.py`, `sync.py`, `entity.py`, `registry.py`, and `domains/timer.py` to eliminate ambiguity — the public API takes `name` (short form), internals use `entity_id` (fully-qualified)
- Direct `Entity` construction still requires fully-qualified `entity_id` since the base class has no domain context

## Motivation

The library previously accepted both short and fully-qualified names on domain accessors, creating inconsistency in usage patterns and documentation. Since the domain is implicit in the accessor (`client.light()` is always `light.*`), requiring the prefix is redundant and accepting both forms leads to divergent user code.

## Test changes

- `test_domain_accessor_reuse`: removed the fully-qualified passthrough assertion, added `test_domain_accessor_rejects_fully_qualified`
- `test_resolve_short_and_full_name`: split into `test_resolve_short_name` and `test_resolve_rejects_fully_qualified`
- All 190 tests pass, coverage 95.34%