### PR TITLE
Resolve entity_picture URLs, add on_reconnect hook, improve callback docs

### DIFF
--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -165,6 +165,7 @@ class HAClient:
         self._timer_cancelled_sub_id = await self.ws.subscribe_events(
             self._on_timer_event, "timer.cancelled"
         )
+        self.ws.on_reconnect(self._on_reconnect)
         self._connected = True
 
     async def close(self) -> None:
@@ -211,6 +212,18 @@ class HAClient:
         if entity is None or not isinstance(entity, _Timer):
             return
         entity._handle_timer_event(event_type, data)  # noqa: SLF001
+
+    async def _on_reconnect(self) -> None:
+        """Refresh all entity state after the WebSocket reconnects.
+
+        This is registered as a reconnect listener so that entities whose
+        state changed while the connection was down are brought up to date
+        automatically.
+        """
+        try:
+            await self.refresh_all()
+        except HAClientError as err:
+            _LOGGER.warning("Post-reconnect refresh failed: %s", err)
 
     async def _call_service(
         self,

--- a/src/haclient/domains/media_player.py
+++ b/src/haclient/domains/media_player.py
@@ -23,13 +23,19 @@ _MAX_BROWSE_NODES = 2000
 _MAX_BROWSE_DEPTH = 6
 
 
-def _now_playing_from_attrs(attrs: dict[str, Any]) -> NowPlaying:
+def _now_playing_from_attrs(
+    attrs: dict[str, Any],
+    base_url: str | None = None,
+) -> NowPlaying:
     """Build a `NowPlaying` from a raw HA attributes dict.
 
     Parameters
     ----------
     attrs : dict
         Raw attributes dictionary from Home Assistant.
+    base_url : str or None, optional
+        The Home Assistant base URL. When provided, a relative
+        ``entity_picture`` path is resolved to an absolute URL.
 
     Returns
     -------
@@ -37,6 +43,9 @@ def _now_playing_from_attrs(attrs: dict[str, Any]) -> NowPlaying:
         A structured snapshot of the currently playing media.
     """
     features = attrs.get("supported_features") or 0
+    picture = attrs.get("entity_picture")
+    if isinstance(picture, str) and base_url and picture.startswith("/"):
+        picture = base_url.rstrip("/") + picture
     return NowPlaying(
         source=attrs.get("source"),
         title=attrs.get("media_title"),
@@ -46,7 +55,7 @@ def _now_playing_from_attrs(attrs: dict[str, Any]) -> NowPlaying:
         content_type=attrs.get("media_content_type"),
         content_id=attrs.get("media_content_id"),
         duration=attrs.get("media_duration"),
-        entity_picture=attrs.get("entity_picture"),
+        entity_picture=picture,
         queue_position=attrs.get("queue_position"),
         queue_size=attrs.get("queue_size"),
         playlist=attrs.get("media_playlist"),
@@ -87,7 +96,9 @@ class NowPlaying:
     duration : int or None
         Media duration in seconds.
     entity_picture : str or None
-        URL of the entity picture / album art.
+        Absolute URL of the entity picture / album art. Relative paths
+        returned by Home Assistant are resolved against the client's
+        base URL automatically.
     queue_position : int or None
         Current position in the play queue.
     queue_size : int or None
@@ -322,8 +333,9 @@ class MediaPlayer(Entity):
         super()._dispatch_granular_events(old_state, new_state)
         old_attrs = (old_state or {}).get("attributes") or {}
         new_attrs = (new_state or {}).get("attributes") or {}
-        old_np = _now_playing_from_attrs(old_attrs)
-        new_np = _now_playing_from_attrs(new_attrs)
+        base = self._client.base_url
+        old_np = _now_playing_from_attrs(old_attrs, base)
+        new_np = _now_playing_from_attrs(new_attrs, base)
         if old_np != new_np:
             for listener in list(self._media_change_listeners):
                 self._schedule_value(listener, old_np, new_np)
@@ -397,7 +409,7 @@ class MediaPlayer(Entity):
         NowPlaying
             The current playback metadata.
         """
-        return _now_playing_from_attrs(self.attributes)
+        return _now_playing_from_attrs(self.attributes, self._client.base_url)
 
     # -- Actions --
 

--- a/src/haclient/domains/sensor.py
+++ b/src/haclient/domains/sensor.py
@@ -22,10 +22,21 @@ class Sensor(Entity):
     def on_value_change(self, func: Any) -> Any:
         """Register a listener for sensor value changes.
 
+        The callback receives the **state strings** directly (e.g.
+        ``"21.5"``, ``"22.0"``) — not the full HA state dictionaries.
+        This fires whenever the state string changes between events.
+
+        Use this instead of :meth:`~haclient.entity.Entity.on_state_change`
+        when you only care about the sensor's value and not the full state
+        object (attributes, timestamps, etc.).
+
         Parameters
         ----------
         func : callable
-            Callback with signature ``(old_state, new_state)``.
+            Callback with signature ``(old_state_str: str | None,
+            new_state_str: str | None)``. Both arguments are raw state
+            strings (e.g. ``"22.5"``, ``"on"``), or ``None`` if the
+            previous/new state is absent.
 
         Returns
         -------

--- a/src/haclient/entity.py
+++ b/src/haclient/entity.py
@@ -270,17 +270,31 @@ class Entity:
             self._state_value_listeners.remove(func)
 
     def on_state_change(self, func: F) -> F:
-        """Register *func* as a listener for state changes on this entity.
+        """Register *func* as a listener for **raw** state changes on this entity.
 
         May be used as a decorator. The callback receives the previous and new
-        raw state objects (``dict`` or ``None``). Coroutine functions are fully
-        supported and will be scheduled on the client's event loop without
-        blocking the dispatcher.
+        **full state dictionaries** as returned by Home Assistant (or ``None``
+        when the entity is created/removed). Each dict contains keys like
+        ``"state"``, ``"attributes"``, ``"last_changed"``, etc.
+
+        .. tip::
+
+            If you only need the state *string* (e.g. ``"on"`` / ``"off"`` or
+            ``"22.5"``), use the domain-specific convenience listener instead.
+            For example, :meth:`Sensor.on_value_change
+            <haclient.domains.sensor.Sensor.on_value_change>` passes
+            ``(old_state_str, new_state_str)`` directly, avoiding the need to
+            extract ``state["state"]`` yourself.
+
+        Coroutine functions are fully supported and will be scheduled on the
+        client's event loop without blocking the dispatcher.
 
         Parameters
         ----------
         func : callable
-            Callback with signature ``(old_state, new_state)``.
+            Callback with signature ``(old_state: dict | None, new_state: dict | None)``.
+            Each argument is the **full** HA state object, not just the state
+            string.
 
         Returns
         -------

--- a/src/haclient/websocket.py
+++ b/src/haclient/websocket.py
@@ -90,6 +90,7 @@ class WebSocketClient:
         self._closing = False
         self._connected = asyncio.Event()
         self._disconnect_listeners: list[Callable[[], Awaitable[None] | None]] = []
+        self._reconnect_listeners: list[Callable[[], Awaitable[None] | None]] = []
 
     @property
     def connected(self) -> bool:
@@ -186,6 +187,28 @@ class WebSocketClient:
             The same *handler*, for use as a decorator.
         """
         self._disconnect_listeners.append(handler)
+        return handler
+
+    def on_reconnect(
+        self, handler: Callable[[], Awaitable[None] | None]
+    ) -> Callable[[], Awaitable[None] | None]:
+        """Register *handler* to be called after a successful reconnection.
+
+        The handler fires once the WebSocket is authenticated and all prior
+        event subscriptions have been re-established. This is the right
+        place to refresh stale state (e.g. call ``refresh_all``).
+
+        Parameters
+        ----------
+        handler : callable
+            A sync or async callable taking no arguments.
+
+        Returns
+        -------
+        callable
+            The same *handler*, for use as a decorator.
+        """
+        self._reconnect_listeners.append(handler)
         return handler
 
     def _next_id(self) -> int:
@@ -369,6 +392,16 @@ class WebSocketClient:
             except Exception:  # pragma: no cover - defensive
                 _LOGGER.exception("Disconnect listener raised")
 
+    async def _notify_reconnect(self) -> None:
+        """Invoke all registered reconnect listeners."""
+        for listener in list(self._reconnect_listeners):
+            try:
+                result = listener()
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:  # pragma: no cover - defensive
+                _LOGGER.exception("Reconnect listener raised")
+
     async def _dispatch(self, msg: dict[str, Any]) -> None:
         """Route an incoming message to the appropriate handler or future."""
         mtype = msg.get("type")
@@ -436,6 +469,7 @@ class WebSocketClient:
                     await self.subscribe_events(handler, event_type)
                 except Exception as err:  # noqa: BLE001
                     _LOGGER.warning("Failed to resubscribe to %s: %s", event_type, err)
+            await self._notify_reconnect()
             return
 
     async def ping(self, *, timeout: float | None = None) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,6 +118,42 @@ async def test_call_service_via_rest_fallback(fake_ha: FakeHA) -> None:
     assert fake_ha.rest_service_calls == [("switch", "toggle", {"entity_id": "switch.x"})]
 
 
+async def test_reconnect_triggers_refresh_all(fake_ha: FakeHA) -> None:
+    """After reconnect, HAClient automatically calls refresh_all."""
+    fake_ha.states = [
+        {"entity_id": "light.kitchen", "state": "off", "attributes": {}},
+    ]
+    ha = HAClient(
+        fake_ha.base_url,
+        fake_ha.token,
+        ping_interval=0,
+        request_timeout=5.0,
+    )
+    light = ha.light("kitchen")
+    await ha.connect()
+    try:
+        assert light.state == "off"
+
+        # Update server state while we're about to disconnect
+        fake_ha.states = [
+            {"entity_id": "light.kitchen", "state": "on", "attributes": {"brightness": 200}},
+        ]
+
+        # Force disconnect
+        for conn in list(fake_ha.connections):
+            await conn.close()
+
+        # Wait for reconnect + auto-refresh
+        for _ in range(50):
+            await asyncio.sleep(0.1)
+            if light.state == "on":
+                break
+        assert light.state == "on"
+        assert light.brightness == 200
+    finally:
+        await ha.close()
+
+
 async def test_create_scene(fake_ha: FakeHA) -> None:
     ha = HAClient(fake_ha.base_url, fake_ha.token, ping_interval=0)
     try:

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -309,6 +309,56 @@ async def test_media_player_state_props() -> None:
         await ha.close()
 
 
+async def test_now_playing_entity_picture_absolute_url() -> None:
+    """entity_picture is resolved to an absolute URL using the client base_url."""
+    ha = HAClient("http://ha.local:8123", "t")
+    try:
+        mp = ha.media_player("livingroom")
+        mp._apply_state(
+            {
+                "state": "playing",
+                "attributes": {
+                    "entity_picture": "/api/media_player_proxy/media_player.livingroom",
+                },
+            }
+        )
+        assert (
+            mp.now_playing.entity_picture
+            == "http://ha.local:8123/api/media_player_proxy/media_player.livingroom"
+        )
+    finally:
+        await ha.close()
+
+
+async def test_now_playing_entity_picture_already_absolute() -> None:
+    """entity_picture that is already absolute is left unchanged."""
+    ha = HAClient("http://ha.local:8123", "t")
+    try:
+        mp = ha.media_player("livingroom")
+        mp._apply_state(
+            {
+                "state": "playing",
+                "attributes": {
+                    "entity_picture": "https://cdn.example.com/art.jpg",
+                },
+            }
+        )
+        assert mp.now_playing.entity_picture == "https://cdn.example.com/art.jpg"
+    finally:
+        await ha.close()
+
+
+async def test_now_playing_entity_picture_none() -> None:
+    """entity_picture is None when not present."""
+    ha = HAClient("http://ha.local:8123", "t")
+    try:
+        mp = ha.media_player("livingroom")
+        mp._apply_state({"state": "playing", "attributes": {}})
+        assert mp.now_playing.entity_picture is None
+    finally:
+        await ha.close()
+
+
 async def test_entity_refresh_via_rest(client: HAClient, fake_ha: FakeHA) -> None:
     fake_ha.states = [
         {"entity_id": "light.kitchen", "state": "on", "attributes": {"brightness": 77}}

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -565,3 +565,43 @@ async def test_close_cancels_pong_waiters(fake_ha: FakeHA) -> None:
     await asyncio.sleep(0.1)
     await ws.close()
     await task
+
+
+async def test_reconnect_listener(fake_ha: FakeHA) -> None:
+    """on_reconnect handler fires after a successful reconnect."""
+    ws = await _make_ws(fake_ha, reconnect=True)
+    called = asyncio.Event()
+
+    @ws.on_reconnect
+    async def on_reconnect() -> None:
+        called.set()
+
+    try:
+        for conn in list(fake_ha.connections):
+            await conn.close()
+
+        await asyncio.wait_for(called.wait(), timeout=5)
+    finally:
+        await ws.close()
+
+
+async def test_reconnect_listener_sync(fake_ha: FakeHA) -> None:
+    """Sync on_reconnect handler also works."""
+    ws = await _make_ws(fake_ha, reconnect=True)
+    flag = _Flag()
+
+    @ws.on_reconnect
+    def on_reconnect() -> None:
+        flag.set()
+
+    try:
+        for conn in list(fake_ha.connections):
+            await conn.close()
+
+        for _ in range(50):
+            await asyncio.sleep(0.1)
+            if flag.is_set():
+                break
+        assert flag.is_set()
+    finally:
+        await ws.close()


### PR DESCRIPTION
## Summary

- **NowPlaying.entity_picture as absolute URL**: Relative paths from HA (e.g. `/api/media_player_proxy/...`) are now resolved to absolute URLs using `client.base_url`, eliminating the need for consumers to manually prepend the base URL.
- **on_reconnect hook + auto-refresh**: `WebSocketClient` gains `on_reconnect()` for registering callbacks after successful reconnection. `HAClient` uses this to automatically call `refresh_all()` post-reconnect, so entity state is re-synced without consumer-side boilerplate.
- **Improved callback docstrings**: `Entity.on_state_change` and `Sensor.on_value_change` now clearly document their callback signatures (`dict | None` vs `str | None`) and cross-reference each other, addressing the discoverability issue that led to defensive `isinstance` guards in consumer code.

All 196 tests pass. Coverage at 95.30%. Lint, format, and mypy clean.