### PR TITLE
Expose on_reconnect and on_disconnect on HAClient

### DIFF
--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from types import TracebackType
 from collections.abc import Awaitable, Callable
+from types import TracebackType
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlparse, urlunparse
 

--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from types import TracebackType
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlparse, urlunparse
 
@@ -173,6 +174,56 @@ class HAClient:
         self._connected = False
         await self.ws.close()
         await self.rest.close()
+
+    def on_reconnect(
+        self, handler: Callable[[], Awaitable[None] | None]
+    ) -> Callable[[], Awaitable[None] | None]:
+        """Register *handler* to be called after a successful reconnection.
+
+        The handler fires once the WebSocket is re-authenticated and all prior
+        event subscriptions have been re-established. Use this to refresh
+        application state that may have gone stale while disconnected.
+
+        Can be used as a decorator::
+
+            @ha.on_reconnect
+            async def refreshed():
+                print("Reconnected!")
+
+        Parameters
+        ----------
+        handler : callable
+            A sync or async callable taking no arguments.
+
+        Returns
+        -------
+        callable
+            The same *handler*, for use as a decorator.
+        """
+        return self.ws.on_reconnect(handler)
+
+    def on_disconnect(
+        self, handler: Callable[[], Awaitable[None] | None]
+    ) -> Callable[[], Awaitable[None] | None]:
+        """Register *handler* to be called when the connection drops.
+
+        Can be used as a decorator::
+
+            @ha.on_disconnect
+            async def lost():
+                print("Disconnected!")
+
+        Parameters
+        ----------
+        handler : callable
+            A sync or async callable taking no arguments.
+
+        Returns
+        -------
+        callable
+            The same *handler*, for use as a decorator.
+        """
+        return self.ws.on_disconnect(handler)
 
     def _on_state_changed_event(self, event: dict[str, Any]) -> None:
         """Dispatch a ``state_changed`` event to the appropriate entity.

--- a/src/haclient/sync.py
+++ b/src/haclient/sync.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import threading
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
 
 from .client import HAClient
@@ -171,6 +171,40 @@ class SyncHAClient:
     def refresh_all(self) -> None:
         """Refresh all registered entities synchronously."""
         self._loop_thread.submit(self._client.refresh_all())
+
+    def on_reconnect(
+        self, handler: Callable[[], Awaitable[None] | None]
+    ) -> Callable[[], Awaitable[None] | None]:
+        """Register *handler* to be called after a successful reconnection.
+
+        Parameters
+        ----------
+        handler : callable
+            A sync or async callable taking no arguments.
+
+        Returns
+        -------
+        callable
+            The same *handler*, for use as a decorator.
+        """
+        return self._client.on_reconnect(handler)
+
+    def on_disconnect(
+        self, handler: Callable[[], Awaitable[None] | None]
+    ) -> Callable[[], Awaitable[None] | None]:
+        """Register *handler* to be called when the connection drops.
+
+        Parameters
+        ----------
+        handler : callable
+            A sync or async callable taking no arguments.
+
+        Returns
+        -------
+        callable
+            The same *handler*, for use as a decorator.
+        """
+        return self._client.on_disconnect(handler)
 
     # -- Domain accessors --
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -283,3 +283,42 @@ async def test_initial_state_fetch_failure_is_logged(fake_ha: FakeHA, caplog: An
         await ha.connect()
     finally:
         await ha.close()
+
+
+async def test_on_reconnect_proxy(fake_ha: FakeHA) -> None:
+    """on_reconnect registered via HAClient fires after reconnection."""
+    ha = HAClient(fake_ha.base_url, fake_ha.token, ping_interval=0, reconnect=True)
+    called = asyncio.Event()
+
+    @ha.on_reconnect
+    async def _reconnected() -> None:
+        called.set()
+
+    try:
+        await ha.connect()
+        # Force-close all server-side connections to trigger a reconnect.
+        for conn in list(fake_ha.connections):
+            await conn.close()
+
+        await asyncio.wait_for(called.wait(), timeout=5)
+    finally:
+        await ha.close()
+
+
+async def test_on_disconnect_proxy(fake_ha: FakeHA) -> None:
+    """on_disconnect registered via HAClient fires when connection drops."""
+    ha = HAClient(fake_ha.base_url, fake_ha.token, ping_interval=0, reconnect=False)
+    called = asyncio.Event()
+
+    @ha.on_disconnect
+    async def _disconnected() -> None:
+        called.set()
+
+    try:
+        await ha.connect()
+        for conn in list(fake_ha.connections):
+            await conn.close()
+
+        await asyncio.wait_for(called.wait(), timeout=5)
+    finally:
+        await ha.close()


### PR DESCRIPTION
## Summary
- Adds `on_reconnect` and `on_disconnect` decorator methods to `HAClient` and `SyncHAClient`, proxying to the underlying `WebSocketClient`.
- Users no longer need to access `client.ws` to register lifecycle callbacks.
- Includes integration tests for both proxies.