### PR TITLE
Add auto-generated architecture diagrams to docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - run: sudo apt-get update && sudo apt-get install -y graphviz
       - run: pip install -e ".[docs]"
+      - run: python tools/generate_diagrams.py
       - run: mkdocs build --strict
       - if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,12 @@
+# Architecture
+
+Auto-generated diagrams showing the structure of the HaClient codebase.
+These are regenerated from source on every docs build.
+
+## Class Diagram
+
+![Class Diagram](architecture/classes.svg)
+
+## Package Diagram
+
+![Package Diagram](architecture/packages.svg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Architecture: architecture.md
   - API Reference:
       - Overview: reference/index.md
       - Client: reference/client.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ docs = [
   "mkdocs>=1.6",
   "mkdocs-material>=9.5",
   "mkdocstrings[python]>=0.25",
+  "pylint>=3.0",
 ]
 
 [project.urls]

--- a/tools/generate_diagrams.py
+++ b/tools/generate_diagrams.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Generate architecture diagrams from source code.
+
+Uses pyreverse to extract class and package relationships, then
+renders them to SVG via Graphviz.  The resulting files are placed
+in ``docs/architecture/`` for inclusion in the MkDocs site.
+
+Requirements
+------------
+- ``pylint`` (provides ``pyreverse``)
+- ``graphviz`` (provides the ``dot`` CLI)
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PROJECT_NAME = "haclient"
+SRC_ROOT = Path("src")
+PACKAGE_PATH = SRC_ROOT / PROJECT_NAME
+OUTPUT_DIR = Path("docs") / "architecture"
+
+DOT_FILES = {
+    f"classes_{PROJECT_NAME}.dot": "classes.svg",
+    f"packages_{PROJECT_NAME}.dot": "packages.svg",
+}
+
+
+def _check_prerequisites() -> None:
+    """Verify that required external tools are available."""
+    if shutil.which("dot") is None:
+        print("ERROR: 'dot' (graphviz) not found on PATH", file=sys.stderr)
+        sys.exit(1)
+
+
+def _run(cmd: list[str], **kwargs: object) -> None:
+    """Run a subprocess, printing the command and failing loudly on error."""
+    print(f"  > {' '.join(cmd)}")
+    subprocess.run(cmd, check=True, **kwargs)  # noqa: S603
+
+
+def main() -> None:
+    """Generate class and package diagrams as SVG files."""
+    _check_prerequisites()
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        print("Running pyreverse ...")
+        _run(
+            [
+                sys.executable,
+                "-m",
+                "pylint.pyreverse.main",
+                "--output",
+                "dot",
+                "--project",
+                PROJECT_NAME,
+                "--source-roots",
+                str(SRC_ROOT),
+                str(PACKAGE_PATH),
+            ],
+            cwd=tmp,
+        )
+
+        for dot_name, svg_name in DOT_FILES.items():
+            dot_file = tmp_path / dot_name
+            if not dot_file.exists():
+                print(f"ERROR: expected {dot_name} not found", file=sys.stderr)
+                sys.exit(1)
+
+            svg_dest = OUTPUT_DIR / svg_name
+            print(f"Rendering {dot_name} -> {svg_dest}")
+            _run(["dot", "-Tsvg", str(dot_file), "-o", str(svg_dest)])
+
+    print("Done. Diagrams written to", OUTPUT_DIR)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a `tools/generate_diagrams.py` script that uses pyreverse + graphviz to generate class and package diagrams as SVG from source code
- Adds `docs/architecture.md` page displaying both diagrams
- Updates the docs CI workflow to install graphviz and run diagram generation before `mkdocs build`
- Adds `pylint` to the `[docs]` optional dependency group

Diagrams are generated in CI only (not committed to the repo) and deployed to GitHub Pages alongside the rest of the docs.