### PR TITLE
Fix diagram generation script to use absolute paths

### DIFF
--- a/tools/generate_diagrams.py
+++ b/tools/generate_diagrams.py
@@ -20,9 +20,10 @@ import tempfile
 from pathlib import Path
 
 PROJECT_NAME = "haclient"
-SRC_ROOT = Path("src")
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src"
 PACKAGE_PATH = SRC_ROOT / PROJECT_NAME
-OUTPUT_DIR = Path("docs") / "architecture"
+OUTPUT_DIR = REPO_ROOT / "docs" / "architecture"
 
 DOT_FILES = {
     f"classes_{PROJECT_NAME}.dot": "classes.svg",


### PR DESCRIPTION
## Summary

- Fixes the docs build failure introduced in #47
- The `generate_diagrams.py` script runs pyreverse with `cwd=tmp` (a temp directory), but was passing relative paths (`src/haclient`) which don't exist there
- Changed path resolution to derive all paths from `REPO_ROOT` (`Path(__file__).resolve().parent.parent`), making the script work regardless of working directory

**Root cause:** `ImportError: No module named src/haclient` — pyreverse couldn't find the package because relative paths were resolved against the temp directory, not the repo root.