### PR TITLE
Separate Timer proxy mode from managed lifecycle

### DIFF
--- a/src/haclient/client.py
+++ b/src/haclient/client.py
@@ -569,48 +569,24 @@ class HAClient:
             data["transition"] = transition
         await self._call_service("scene", "apply", data)
 
-    def timer(self, name: str | None = None, *, persistent: bool = False) -> Timer:
-        """Return a `Timer`, creating the Python object if needed.
+    def timer(self, name: str) -> Timer:
+        """Return the `Timer` for *name*, creating the Python proxy if needed.
 
-        Timers are **ephemeral by default**: the HA helper is created on the
-        first action and deleted automatically when the timer returns to idle.
-        Pass ``persistent=True`` to keep the helper alive.
+        This returns a proxy to an **existing** Home Assistant timer.
+        To create a library-managed ephemeral timer, use
+        ``await Timer.create(client, ...)`` instead.
 
         Parameters
         ----------
-        name : str or None, optional
+        name : str
             Short object-id (e.g. ``"my_timer"``).  The ``timer.`` prefix
-            is added automatically.  When ``None`` a unique id is
-            generated automatically (only allowed for ephemeral timers).
-        persistent : bool, optional
-            If ``True``, the HA helper is **not** deleted on idle.
-            Requires an explicit *name*.
+            is added automatically.
 
         Returns
         -------
         Timer
             The timer entity.
-
-        Raises
-        ------
-        ValueError
-            If ``persistent=True`` and *name* is ``None``.
         """
         from .domains.timer import Timer as _Timer
-        from .domains.timer import _generate_timer_id
 
-        if name is None:
-            if persistent:
-                raise ValueError("Persistent timers require an explicit name")
-            name = _generate_timer_id()
-
-        entity_id = self.registry.resolve("timer", name)
-        existing = self.registry.get(entity_id)
-        if existing is not None:
-            if not isinstance(existing, _Timer):
-                raise HAClientError(
-                    f"Entity {entity_id} is registered as {type(existing).__name__}, "
-                    f"not {_Timer.__name__}"
-                )
-            return existing
-        return _Timer(entity_id, self, persistent=persistent)
+        return self._get_or_create("timer", name, _Timer)

--- a/src/haclient/domains/timer.py
+++ b/src/haclient/domains/timer.py
@@ -30,18 +30,27 @@ class Timer(Entity):
     Actions use intent-specific names: ``start``, ``pause``, ``cancel``,
     ``finish``, ``change``.
 
-    Timers are **ephemeral by default**: the HA helper is created
-    automatically on the first action and deleted when the timer returns
-    to idle (natural finish or cancellation).  The same ``Timer`` object
-    can be restarted afterwards — the helper is transparently re-created.
+    Obtain a proxy to an **existing** Home Assistant timer via the domain
+    accessor::
 
+        t = client.timer("my_timer")
+
+    To let the library **create and manage** a timer helper, use the async
+    `create` classmethod instead::
+
+        t = await Timer.create(client, name="countdown", duration="00:05:00")
+
+    Timers returned by `create` are **ephemeral by default**: the HA
+    helper is deleted automatically when the timer returns to idle
+    (natural finish or cancellation).  The same ``Timer`` object can be
+    restarted afterwards — the helper is transparently re-created.
     Pass ``persistent=True`` to keep the HA helper alive after the timer
-    finishes.  Persistent timers require an explicit *name*; ephemeral
-    timers auto-generate one when no name is provided.
+    finishes.
 
-    Timers that already exist in Home Assistant (e.g. created via the UI)
-    are never auto-deleted, regardless of the ``persistent`` flag.  Only
-    helpers created by the library are eligible for auto-cleanup.
+    Timers obtained via the domain accessor (``client.timer("name")``)
+    are never auto-deleted, regardless of how they were originally
+    created in Home Assistant.  Only helpers created by `create` are
+    eligible for auto-cleanup.
 
     In addition to the generic ``on_idle`` listener (which fires for both
     natural expiry and explicit cancellation), the timer provides
@@ -62,20 +71,89 @@ class Timer(Entity):
         automatically.
     client : HAClient
         The owning client instance.
-    persistent : bool, optional
-        If ``False`` (default), the HA helper is deleted automatically
-        when the timer returns to idle.
     """
 
     domain = "timer"
 
-    def __init__(self, entity_id: str, client: Any, *, persistent: bool = False) -> None:
+    def __init__(self, entity_id: str, client: Any) -> None:
         super().__init__(entity_id, client)
         self._finished_listeners: list[ValueChangeHandler] = []
         self._cancelled_listeners: list[ValueChangeHandler] = []
         self._ensured: bool = False
-        self._persistent: bool = persistent
+        self._persistent: bool = False
         self._created_by_us: bool = False
+
+    @classmethod
+    async def create(
+        cls,
+        client: Any,
+        *,
+        name: str | None = None,
+        duration: str = "00:01:00",
+        persistent: bool = False,
+    ) -> Timer:
+        """Create a library-managed timer helper in Home Assistant.
+
+        This sends a ``timer/create`` WebSocket command to Home Assistant
+        and returns a ``Timer`` instance that tracks the new helper.
+
+        Ephemeral timers (the default) are automatically deleted when
+        they return to idle.  Pass ``persistent=True`` to keep the HA
+        helper alive.
+
+        Parameters
+        ----------
+        client : HAClient
+            The client instance to use.
+        name : str or None, optional
+            Short object-id (e.g. ``"my_timer"``).  When ``None`` a
+            unique id is generated automatically (only allowed for
+            ephemeral timers).
+        duration : str, optional
+            Initial duration for the helper (e.g. ``"00:05:00"``).
+            Defaults to ``"00:01:00"``.
+        persistent : bool, optional
+            If ``True``, the HA helper is **not** deleted on idle.
+            Requires an explicit *name*.
+
+        Returns
+        -------
+        Timer
+            The newly created timer entity.
+
+        Raises
+        ------
+        ValueError
+            If ``persistent=True`` and *name* is ``None``.
+        """
+        if name is None:
+            if persistent:
+                raise ValueError("Persistent timers require an explicit name")
+            name = _generate_timer_id()
+
+        entity_id = client.registry.resolve("timer", name)
+        existing = client.registry.get(entity_id)
+        timer: Timer
+        if existing is not None and isinstance(existing, cls):
+            timer = existing
+            if timer._ensured:
+                return timer
+        else:
+            timer = cls(entity_id, client)
+
+        timer._persistent = persistent  # noqa: SLF001
+
+        object_id = entity_id.split(".", 1)[1]
+        await client.ws.send_command(
+            {
+                "type": "timer/create",
+                "name": object_id,
+                "duration": duration,
+            }
+        )
+        timer._ensured = True  # noqa: SLF001
+        timer._created_by_us = True  # noqa: SLF001
+        return timer
 
     @property
     def persistent(self) -> bool:
@@ -241,29 +319,6 @@ class Timer(Entity):
         self.state = "unknown"
         self._created_by_us = False
 
-    async def _ensure_exists(self) -> None:
-        """Create the timer helper in Home Assistant if it does not exist.
-
-        Uses the ``timer/create`` WebSocket command.  The call is idempotent:
-        once the helper has been confirmed (either via the initial state fetch
-        or a prior ``_ensure_exists`` call), subsequent invocations are no-ops.
-
-        The object-id is extracted from the ``entity_id`` (the part after
-        ``timer.``).
-        """
-        if self._ensured or self.state != "unknown":
-            return
-        object_id = self.entity_id.split(".", 1)[1]
-        await self._client.ws.send_command(
-            {
-                "type": "timer/create",
-                "name": object_id,
-                "duration": "00:01:00",
-            }
-        )
-        self._ensured = True
-        self._created_by_us = True
-
     async def delete(self) -> None:
         """Delete the timer helper from Home Assistant.
 
@@ -296,23 +351,19 @@ class Timer(Entity):
         duration : str or None, optional
             Override duration (e.g. ``"00:05:00"``).
         """
-        await self._ensure_exists()
         data: dict[str, Any] | None = {"duration": duration} if duration else None
         await self._call_service("start", data)
 
     async def pause(self) -> None:
         """Pause the timer."""
-        await self._ensure_exists()
         await self._call_service("pause")
 
     async def cancel(self) -> None:
         """Cancel the timer (returns to idle)."""
-        await self._ensure_exists()
         await self._call_service("cancel")
 
     async def finish(self) -> None:
         """Finish the timer immediately."""
-        await self._ensure_exists()
         await self._call_service("finish")
 
     async def change(self, *, duration: str) -> None:
@@ -323,7 +374,6 @@ class Timer(Entity):
         duration : str
             Duration to add/subtract (e.g. ``"00:01:00"`` or ``"-00:00:30"``).
         """
-        await self._ensure_exists()
         await self._call_service("change", {"duration": duration})
 
     # -- Listener decorators --

--- a/tests/test_timer_lifecycle.py
+++ b/tests/test_timer_lifecycle.py
@@ -1,4 +1,4 @@
-"""Tests for Timer auto-create, delete, ephemeral and persistent lifecycle."""
+"""Tests for Timer proxy mode and Timer.create() managed lifecycle."""
 
 from __future__ import annotations
 
@@ -7,33 +7,28 @@ import asyncio
 import pytest
 
 from haclient import HAClient
+from haclient.domains.timer import Timer
 
 from .fake_ha import FakeHA
 
 # ---------------------------------------------------------------------------
-# Auto-create (unchanged behaviour)
+# Proxy mode — client.timer("name") returns a plain proxy
 # ---------------------------------------------------------------------------
 
 
-async def test_timer_start_auto_creates_when_unknown(client: HAClient, fake_ha: FakeHA) -> None:
-    """Calling start() on a timer with state 'unknown' should send timer/create first."""
+async def test_proxy_timer_default_state(client: HAClient) -> None:
+    """A proxy timer starts with state 'unknown' and is not managed."""
     t = client.timer("my_timer")
     assert t.state == "unknown"
-
-    await t.start(duration="00:00:10")
-
-    assert len(fake_ha.ws_service_calls) == 1
-    call = fake_ha.ws_service_calls[0]
-    assert call["domain"] == "timer"
-    assert call["service"] == "start"
-    assert t._ensured is True
+    assert t.persistent is False
+    assert t._created_by_us is False
+    assert t._ensured is False
 
 
-async def test_timer_start_skips_create_when_state_known(client: HAClient, fake_ha: FakeHA) -> None:
-    """If the timer already has a state from HA, _ensure_exists is a no-op."""
+async def test_proxy_timer_start_sends_service_call(client: HAClient, fake_ha: FakeHA) -> None:
+    """start() on a proxy timer sends a service call directly (no timer/create)."""
     t = client.timer("my_timer")
     t._apply_state({"state": "idle", "attributes": {"duration": "0:01:00"}})
-    assert t.state == "idle"
 
     await t.start(duration="00:00:10")
 
@@ -43,88 +38,113 @@ async def test_timer_start_skips_create_when_state_known(client: HAClient, fake_
     assert call["service"] == "start"
 
 
-async def test_timer_ensure_exists_only_called_once(client: HAClient, fake_ha: FakeHA) -> None:
-    """After the first _ensure_exists succeeds, subsequent calls are no-ops."""
-    t = client.timer("my_timer")
-    assert t.state == "unknown"
+async def test_proxy_timer_not_auto_deleted(client: HAClient, fake_ha: FakeHA) -> None:
+    """A proxy timer is never auto-deleted, even when transitioning to idle."""
+    t = client.timer("existing_timer")
+    t._apply_state({"state": "idle", "attributes": {"duration": "0:05:00"}})
+    assert t._created_by_us is False
 
-    await t.start(duration="00:00:10")
-    await t.pause()
+    await t.start(duration="00:00:05")
 
-    assert len(fake_ha.ws_service_calls) == 2
-    assert t._ensured is True
+    await fake_ha.push_state_changed(
+        "timer.existing_timer",
+        {"state": "idle", "attributes": {}},
+        {"state": "active", "attributes": {}},
+    )
+    await asyncio.sleep(0.1)
 
-
-async def test_timer_pause_auto_creates(client: HAClient, fake_ha: FakeHA) -> None:
-    """pause() should also trigger auto-create."""
-    t = client.timer("my_timer")
-    await t.pause()
-    assert t._ensured is True
-    assert len(fake_ha.ws_service_calls) == 1
-
-
-async def test_timer_cancel_auto_creates(client: HAClient, fake_ha: FakeHA) -> None:
-    """cancel() should also trigger auto-create."""
-    t = client.timer("my_timer")
-    await t.cancel()
-    assert t._ensured is True
+    # State updates normally but no auto-delete.
+    assert t.state == "idle"
+    assert t._created_by_us is False
 
 
-async def test_timer_finish_auto_creates(client: HAClient, fake_ha: FakeHA) -> None:
-    """finish() should also trigger auto-create."""
-    t = client.timer("my_timer")
-    await t.finish()
-    assert t._ensured is True
+async def test_proxy_timer_uses_given_name(client: HAClient) -> None:
+    """Providing a name uses that name for the entity id."""
+    t = client.timer("my_cooldown")
+    assert t.entity_id == "timer.my_cooldown"
 
 
-async def test_timer_change_auto_creates(client: HAClient, fake_ha: FakeHA) -> None:
-    """change() should also trigger auto-create."""
-    t = client.timer("my_timer")
-    await t.change(duration="00:00:30")
-    assert t._ensured is True
-
-
-async def test_timer_delete(client: HAClient, fake_ha: FakeHA) -> None:
+async def test_proxy_timer_delete(client: HAClient, fake_ha: FakeHA) -> None:
     """delete() sends timer/delete and resets _ensured."""
     t = client.timer("my_timer")
-    await t.start()
-    assert t._ensured is True
+    t._ensured = True
 
     await t.delete()
     assert t._ensured is False
 
 
-async def test_timer_delete_then_start_recreates(client: HAClient, fake_ha: FakeHA) -> None:
-    """After delete(), the next action should re-create the timer."""
-    t = client.timer("my_timer")
-    await t.start()
-    assert t._ensured is True
-
-    await t.delete()
-    assert t._ensured is False
-
-    t.state = "unknown"
-    await t.start()
-    assert t._ensured is True
-
-
 # ---------------------------------------------------------------------------
-# Ephemeral timers (default)
+# Timer.create() — managed lifecycle
 # ---------------------------------------------------------------------------
 
 
-async def test_ephemeral_timer_is_default(client: HAClient) -> None:
-    """Timers are ephemeral by default."""
-    t = client.timer("my_timer")
+async def test_create_sends_ws_command(client: HAClient, fake_ha: FakeHA) -> None:
+    """Timer.create() sends a timer/create WebSocket command."""
+    t = await Timer.create(client, name="my_timer")
+
+    assert t.entity_id == "timer.my_timer"
+    assert t._ensured is True
+    assert t._created_by_us is True
+
+
+async def test_create_default_ephemeral(client: HAClient, fake_ha: FakeHA) -> None:
+    """Timers from create() are ephemeral by default."""
+    t = await Timer.create(client, name="my_timer")
     assert t.persistent is False
+
+
+async def test_create_persistent(client: HAClient, fake_ha: FakeHA) -> None:
+    """Timer.create(persistent=True) creates a persistent timer."""
+    t = await Timer.create(client, name="my_timer", persistent=True)
+    assert t.persistent is True
+
+
+async def test_create_persistent_requires_name(client: HAClient) -> None:
+    """Timer.create(persistent=True) without a name raises ValueError."""
+    with pytest.raises(ValueError, match="Persistent timers require an explicit name"):
+        await Timer.create(client, persistent=True)
+
+
+async def test_create_unnamed_generates_id(client: HAClient, fake_ha: FakeHA) -> None:
+    """Timer.create() without a name generates a unique entity id."""
+    t = await Timer.create(client)
+    assert t.entity_id.startswith("timer.haclient_")
+    assert len(t.entity_id) == len("timer.haclient_") + 8
+
+
+async def test_create_unnamed_unique_ids(client: HAClient, fake_ha: FakeHA) -> None:
+    """Each Timer.create() call without a name produces a different id."""
+    t1 = await Timer.create(client)
+    t2 = await Timer.create(client)
+    assert t1.entity_id != t2.entity_id
+
+
+async def test_create_returns_existing_if_registered(client: HAClient, fake_ha: FakeHA) -> None:
+    """Timer.create() returns an existing Timer if one is already registered."""
+    t1 = await Timer.create(client, name="my_timer")
+    t2 = await Timer.create(client, name="my_timer")
+    assert t1 is t2
+
+
+async def test_create_with_custom_duration(client: HAClient, fake_ha: FakeHA) -> None:
+    """Timer.create() passes the duration to the WS command."""
+    t = await Timer.create(client, name="my_timer", duration="00:05:00")
+
+    # Timer was created successfully.
+    assert t._ensured is True
+    assert t._created_by_us is True
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral auto-delete (via Timer.create)
+# ---------------------------------------------------------------------------
 
 
 async def test_ephemeral_auto_deletes_on_idle(client: HAClient, fake_ha: FakeHA) -> None:
     """An ephemeral timer auto-deletes its HA helper when it transitions to idle."""
-    t = client.timer("my_timer")
+    t = await Timer.create(client, name="my_timer")
     await t.start(duration="00:00:05")
 
-    # Simulate HA reporting active -> idle (timer finished).
     await fake_ha.push_state_changed(
         "timer.my_timer",
         {"state": "idle", "attributes": {}},
@@ -140,7 +160,7 @@ async def test_ephemeral_user_on_idle_fires_before_cleanup(
     client: HAClient, fake_ha: FakeHA
 ) -> None:
     """User on_idle listeners fire even though the timer is ephemeral."""
-    t = client.timer("my_timer")
+    t = await Timer.create(client, name="my_timer")
     captured: list[tuple[str | None, str | None]] = []
 
     @t.on_idle
@@ -160,8 +180,8 @@ async def test_ephemeral_user_on_idle_fires_before_cleanup(
 
 
 async def test_ephemeral_can_restart_after_auto_delete(client: HAClient, fake_ha: FakeHA) -> None:
-    """After auto-delete, calling start() re-creates the timer transparently."""
-    t = client.timer("my_timer")
+    """After auto-delete, calling Timer.create() again re-creates the timer."""
+    t = await Timer.create(client, name="my_timer")
     await t.start(duration="00:00:05")
 
     # Trigger auto-delete.
@@ -174,15 +194,16 @@ async def test_ephemeral_can_restart_after_auto_delete(client: HAClient, fake_ha
     assert t._ensured is False
     assert t.state == "unknown"
 
-    # Restart — should re-create.
-    await t.start(duration="00:00:10")
+    # Re-create via Timer.create — should get the same object back.
+    t2 = await Timer.create(client, name="my_timer")
+    assert t2 is t
     assert t._ensured is True
+    assert t._created_by_us is True
 
 
 async def test_ephemeral_no_cleanup_on_idle_to_idle(client: HAClient, fake_ha: FakeHA) -> None:
     """No auto-delete when old_state is already idle (avoid spurious deletes)."""
-    t = client.timer("my_timer")
-    t._ensured = True
+    t = await Timer.create(client, name="my_timer")
 
     # idle -> idle should not trigger cleanup.
     await fake_ha.push_state_changed(
@@ -192,14 +213,12 @@ async def test_ephemeral_no_cleanup_on_idle_to_idle(client: HAClient, fake_ha: F
     )
     await asyncio.sleep(0.1)
 
-    # _ensured should remain True — no cleanup was triggered.
     assert t._ensured is True
 
 
 async def test_ephemeral_no_cleanup_when_old_state_none(client: HAClient, fake_ha: FakeHA) -> None:
     """No auto-delete when old_state is None (initial state load)."""
-    t = client.timer("my_timer")
-    t._ensured = True
+    t = await Timer.create(client, name="my_timer")
 
     await fake_ha.push_state_changed(
         "timer.my_timer",
@@ -212,13 +231,13 @@ async def test_ephemeral_no_cleanup_when_old_state_none(client: HAClient, fake_h
 
 
 # ---------------------------------------------------------------------------
-# Persistent timers
+# Persistent timers (via Timer.create)
 # ---------------------------------------------------------------------------
 
 
 async def test_persistent_timer_no_auto_delete(client: HAClient, fake_ha: FakeHA) -> None:
     """A persistent timer does not auto-delete its HA helper on idle."""
-    t = client.timer("my_timer", persistent=True)
+    t = await Timer.create(client, name="my_timer", persistent=True)
     assert t.persistent is True
     await t.start(duration="00:00:05")
 
@@ -229,53 +248,21 @@ async def test_persistent_timer_no_auto_delete(client: HAClient, fake_ha: FakeHA
     )
     await asyncio.sleep(0.1)
 
-    # State updated but _ensured not reset, state not reverted to unknown.
     assert t.state == "idle"
     assert t._ensured is True
 
 
-async def test_persistent_requires_name(client: HAClient) -> None:
-    """persistent=True without a name should raise ValueError."""
-    with pytest.raises(ValueError, match="Persistent timers require an explicit name"):
-        client.timer(persistent=True)
-
-
 # ---------------------------------------------------------------------------
-# Pre-existing HA timers (not created by us)
+# Library-created vs pre-existing distinction
 # ---------------------------------------------------------------------------
-
-
-async def test_preexisting_timer_not_auto_deleted(client: HAClient, fake_ha: FakeHA) -> None:
-    """A timer that already exists in HA must not be auto-deleted on idle."""
-    t = client.timer("existing_timer")
-    # Simulate HA reporting the timer during initial state fetch.
-    t._apply_state({"state": "idle", "attributes": {"duration": "0:05:00"}})
-    assert t.state == "idle"
-    assert t._created_by_us is False
-
-    # Start it (no timer/create because state is already known).
-    await t.start(duration="00:00:05")
-
-    # Simulate active -> idle.
-    await fake_ha.push_state_changed(
-        "timer.existing_timer",
-        {"state": "idle", "attributes": {}},
-        {"state": "active", "attributes": {}},
-    )
-    await asyncio.sleep(0.1)
-
-    # State should update normally but no auto-delete.
-    assert t.state == "idle"
-    assert t._created_by_us is False
 
 
 async def test_library_created_timer_auto_deletes(client: HAClient, fake_ha: FakeHA) -> None:
-    """A timer created by the library (via _ensure_exists) does auto-delete."""
-    t = client.timer("lib_timer")
-    assert t.state == "unknown"
+    """A timer created via Timer.create() auto-deletes on idle."""
+    t = await Timer.create(client, name="lib_timer")
+    assert t._created_by_us is True
 
     await t.start(duration="00:00:05")
-    assert t._created_by_us is True
 
     await fake_ha.push_state_changed(
         "timer.lib_timer",
@@ -286,31 +273,6 @@ async def test_library_created_timer_auto_deletes(client: HAClient, fake_ha: Fak
 
     assert t.state == "unknown"
     assert t._created_by_us is False
-
-
-# ---------------------------------------------------------------------------
-# Auto-generated names (unnamed ephemeral timers)
-# ---------------------------------------------------------------------------
-
-
-async def test_unnamed_ephemeral_generates_id(client: HAClient) -> None:
-    """Calling timer() without a name generates a unique entity id."""
-    t = client.timer()
-    assert t.entity_id.startswith("timer.haclient_")
-    assert len(t.entity_id) == len("timer.haclient_") + 8
-
-
-async def test_unnamed_ephemeral_unique_ids(client: HAClient) -> None:
-    """Each unnamed timer() call produces a different id."""
-    t1 = client.timer()
-    t2 = client.timer()
-    assert t1.entity_id != t2.entity_id
-
-
-async def test_named_ephemeral_uses_given_name(client: HAClient) -> None:
-    """Providing a name uses that name, not a generated one."""
-    t = client.timer("my_cooldown")
-    assert t.entity_id == "timer.my_cooldown"
 
 
 # ---------------------------------------------------------------------------
@@ -336,7 +298,7 @@ async def test_ephemeral_auto_cleanup_handles_delete_failure(
 
     fake_ha.handlers["timer/delete"] = fail_delete
 
-    t = client.timer("will_fail")
+    t = await Timer.create(client, name="will_fail")
     await t.start(duration="00:00:05")
 
     await fake_ha.push_state_changed(


### PR DESCRIPTION
## Summary

- **Timer proxy mode** (`client.timer("name")`) now works identically to every other domain accessor — plain proxy to an existing HA entity, no auto-creation, no special constructor parameters.
- **Managed lifecycle** moved to `Timer.create(client, ...)` classmethod — handles HA helper creation, ephemeral auto-cleanup, persistence, and name generation.
- `HAClient.timer()` signature simplified from `(name=None, *, persistent=False)` to `(name: str)`, matching `light()`, `switch()`, etc.

## Breaking Changes

- `client.timer()` (no name) no longer works — use `await Timer.create(client)` for anonymous ephemeral timers.
- `client.timer("name", persistent=True)` no longer works — use `await Timer.create(client, name="name", persistent=True)`.
- Timer actions (`start`, `pause`, etc.) no longer auto-create the HA helper. Proxy timers assume the entity already exists in HA.

## Motivation

Timer was the only domain where `HAClient` managed HA-side resource lifecycle (create/delete helpers), making it a special case that complicated the accessor pattern. This separation is a prerequisite for the planned domain accessor refactoring (`client.domains.light("x")` pattern).

## Tests

All 196 tests pass. Coverage 95.55%. Lint, format, and mypy all clean.