### PR TITLE
Add NumPy-style docstrings to public API

### DIFF
--- a/src/haclient/api.py
+++ b/src/haclient/api.py
@@ -309,14 +309,41 @@ class HAClient:
         self,
         handler: Callable[[], Awaitable[None] | None],
     ) -> Callable[[], Awaitable[None] | None]:
-        """Register a disconnect listener."""
+        """Register a disconnect listener.
+
+        Parameters
+        ----------
+        handler : callable
+            Sync or async zero-argument callable invoked when the
+            WebSocket connection drops.
+
+        Returns
+        -------
+        callable
+            The same *handler*, returned so the method can be used as a
+            decorator.
+        """
         return self._connection.on_disconnect(handler)
 
     def on_reconnect(
         self,
         handler: Callable[[], Awaitable[None] | None],
     ) -> Callable[[], Awaitable[None] | None]:
-        """Register a reconnect listener."""
+        """Register a reconnect listener.
+
+        Parameters
+        ----------
+        handler : callable
+            Sync or async zero-argument callable invoked after the
+            WebSocket reconnects successfully and the state cache has
+            been re-primed.
+
+        Returns
+        -------
+        callable
+            The same *handler*, returned so the method can be used as a
+            decorator.
+        """
         return self._connection.on_reconnect(handler)
 
     # -- Domain accessors --------------------------------------------
@@ -352,31 +379,115 @@ class HAClient:
     # -- Built-in typed accessors ------------------------------------
 
     def light(self, name: str) -> Light:
-        """Return the `Light` for *name*."""
+        """Return the `Light` for *name*.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name (without the ``light.`` prefix) or full
+            ``light.<name>`` entity id.
+
+        Returns
+        -------
+        Light
+            The (cached) entity instance.
+        """
         return cast("Light", self._accessors["light"][name])
 
     def switch(self, name: str) -> Switch:
-        """Return the `Switch` for *name*."""
+        """Return the `Switch` for *name*.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name (without the ``switch.`` prefix) or full
+            ``switch.<name>`` entity id.
+
+        Returns
+        -------
+        Switch
+            The (cached) entity instance.
+        """
         return cast("Switch", self._accessors["switch"][name])
 
     def climate(self, name: str) -> Climate:
-        """Return the `Climate` for *name*."""
+        """Return the `Climate` for *name*.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name (without the ``climate.`` prefix) or full
+            ``climate.<name>`` entity id.
+
+        Returns
+        -------
+        Climate
+            The (cached) entity instance.
+        """
         return cast("Climate", self._accessors["climate"][name])
 
     def cover(self, name: str) -> Cover:
-        """Return the `Cover` for *name*."""
+        """Return the `Cover` for *name*.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name (without the ``cover.`` prefix) or full
+            ``cover.<name>`` entity id.
+
+        Returns
+        -------
+        Cover
+            The (cached) entity instance.
+        """
         return cast("Cover", self._accessors["cover"][name])
 
     def sensor(self, name: str) -> Sensor:
-        """Return the `Sensor` for *name*."""
+        """Return the `Sensor` for *name*.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name (without the ``sensor.`` prefix) or full
+            ``sensor.<name>`` entity id.
+
+        Returns
+        -------
+        Sensor
+            The (cached) entity instance.
+        """
         return cast("Sensor", self._accessors["sensor"][name])
 
     def binary_sensor(self, name: str) -> BinarySensor:
-        """Return the `BinarySensor` for *name*."""
+        """Return the `BinarySensor` for *name*.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name (without the ``binary_sensor.`` prefix) or
+            full ``binary_sensor.<name>`` entity id.
+
+        Returns
+        -------
+        BinarySensor
+            The (cached) entity instance.
+        """
         return cast("BinarySensor", self._accessors["binary_sensor"][name])
 
     def media_player(self, name: str) -> MediaPlayer:
-        """Return the `MediaPlayer` for *name*."""
+        """Return the `MediaPlayer` for *name*.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name (without the ``media_player.`` prefix) or
+            full ``media_player.<name>`` entity id.
+
+        Returns
+        -------
+        MediaPlayer
+            The (cached) entity instance.
+        """
         return cast("MediaPlayer", self._accessors["media_player"][name])
 
     @property

--- a/src/haclient/core/connection.py
+++ b/src/haclient/core/connection.py
@@ -87,11 +87,37 @@ class Connection:
         await self._rest.close()
 
     def on_disconnect(self, handler: DisconnectListener) -> DisconnectListener:
-        """Register a disconnect listener (forwarded to the WS adapter)."""
+        """Register a disconnect listener (forwarded to the WS adapter).
+
+        Parameters
+        ----------
+        handler : DisconnectListener
+            Sync or async zero-argument callable invoked when the
+            underlying WebSocket connection drops.
+
+        Returns
+        -------
+        DisconnectListener
+            The same *handler*, returned so the method can be used as a
+            decorator.
+        """
         return self._ws.on_disconnect(handler)
 
     def on_reconnect(self, handler: ReconnectListener) -> ReconnectListener:
-        """Register a reconnect listener (forwarded to the WS adapter)."""
+        """Register a reconnect listener (forwarded to the WS adapter).
+
+        Parameters
+        ----------
+        handler : ReconnectListener
+            Sync or async zero-argument callable invoked after the
+            underlying WebSocket reconnects.
+
+        Returns
+        -------
+        ReconnectListener
+            The same *handler*, returned so the method can be used as a
+            decorator.
+        """
         return self._ws.on_reconnect(handler)
 
     async def _on_reconnect(self) -> None:

--- a/src/haclient/core/events.py
+++ b/src/haclient/core/events.py
@@ -77,6 +77,14 @@ class EventBus:
 
         If the last handler for *event_type* is removed the WebSocket
         subscription is also cancelled.
+
+        Parameters
+        ----------
+        event_type : str
+            The Home Assistant event type to unsubscribe from.
+        handler : callable
+            The exact handler previously passed to `subscribe`. Removing
+            an unknown handler is a no-op.
         """
         handlers = self._handlers.get(event_type)
         if not handlers:
@@ -180,6 +188,15 @@ class EventBus:
         After a reconnect, the underlying WS adapter re-subscribes for us
         (it stores the original handlers). All we need to do is invoke the
         optional *on_reconnect* callback (e.g. `StateStore.refresh_all`).
+
+        Parameters
+        ----------
+        on_reconnect : callable or None, optional
+            Sync or async callable invoked once the WebSocket reconnects.
+            Receives an empty event dict for compatibility with the
+            generic event-handler signature. ``None`` (the default) is a
+            no-op — useful for callers that only need the WS adapter's
+            built-in re-subscription behaviour.
         """
         if on_reconnect is None:
             return

--- a/src/haclient/core/plugins.py
+++ b/src/haclient/core/plugins.py
@@ -163,9 +163,36 @@ class EntityFactoryProtocol:
     """
 
     def get_or_create(self, spec: DomainSpec[Any], name: str) -> Any:  # pragma: no cover
+        """Return the entity for *spec*/*name*, creating it on first use.
+
+        Parameters
+        ----------
+        spec : DomainSpec
+            The spec describing the entity's domain.
+        name : str
+            Short entity name or full ``<domain>.<name>`` entity id.
+
+        Returns
+        -------
+        Entity
+            The (possibly newly created) entity instance.
+        """
         raise NotImplementedError
 
     def in_domain(self, spec: DomainSpec[Any]) -> list[Any]:  # pragma: no cover
+        """Return every registered entity belonging to *spec*'s domain.
+
+        Parameters
+        ----------
+        spec : DomainSpec
+            The spec describing the domain to enumerate.
+
+        Returns
+        -------
+        list of Entity
+            All entities currently in the registry whose id starts with
+            ``"<spec.name>."``.
+        """
         raise NotImplementedError
 
 
@@ -228,6 +255,16 @@ class DomainRegistry:
     def get(self, name: str) -> DomainSpec[Any]:
         """Return the spec registered for *name* or raise.
 
+        Parameters
+        ----------
+        name : str
+            The HA domain name to look up.
+
+        Returns
+        -------
+        DomainSpec
+            The registered spec.
+
         Raises
         ------
         HAClientError
@@ -251,7 +288,19 @@ class DomainRegistry:
         return list(self._specs.keys())
 
     def filter(self, names: Iterable[str]) -> list[DomainSpec[Any]]:
-        """Return only the specs whose names are in *names*."""
+        """Return only the specs whose names are in *names*.
+
+        Parameters
+        ----------
+        names : iterable of str
+            Allowed domain names. Unknown names are silently ignored.
+
+        Returns
+        -------
+        list of DomainSpec
+            Registered specs filtered to the requested subset, in
+            registration order.
+        """
         wanted = set(names)
         return [s for s in self._specs.values() if s.name in wanted]
 

--- a/src/haclient/domains/binary_sensor.py
+++ b/src/haclient/domains/binary_sensor.py
@@ -21,11 +21,37 @@ class BinarySensor(Entity):
     # -- Listener decorators ------------------------------------------
 
     def on_activate(self, func: Any) -> Any:
-        """Register a listener for when the sensor activates (state ``on``)."""
+        """Register a listener for when the sensor activates (state ``on``).
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``on`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned so the method can be used as a
+            decorator.
+        """
         return self._register_state_transition_listener("on", func)
 
     def on_deactivate(self, func: Any) -> Any:
-        """Register a listener for when the sensor deactivates (state ``off``)."""
+        """Register a listener for when the sensor deactivates (state ``off``).
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``off`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned so the method can be used as a
+            decorator.
+        """
         return self._register_state_transition_listener("off", func)
 
     # -- State properties ---------------------------------------------

--- a/src/haclient/domains/climate.py
+++ b/src/haclient/domains/climate.py
@@ -20,15 +20,48 @@ class Climate(Entity):
     # -- Listener decorators ------------------------------------------
 
     def on_hvac_mode_change(self, func: Any) -> Any:
-        """Register a listener for HVAC mode changes."""
+        """Register a listener for HVAC mode changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new HVAC mode string (e.g. ``"heat"``).
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_value_listener(func)
 
     def on_temperature_change(self, func: Any) -> Any:
-        """Register a listener for current temperature changes."""
+        """Register a listener for current temperature changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new ``current_temperature`` value.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_attr_listener("current_temperature", func)
 
     def on_target_temperature_change(self, func: Any) -> Any:
-        """Register a listener for target temperature changes."""
+        """Register a listener for target temperature changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new target temperature value.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_attr_listener("temperature", func)
 
     # -- State properties ---------------------------------------------
@@ -65,18 +98,43 @@ class Climate(Entity):
         hvac_mode: str | None = None,
         **extra: Any,
     ) -> None:
-        """Set the target temperature, optionally changing HVAC mode."""
+        """Set the target temperature, optionally changing HVAC mode.
+
+        Parameters
+        ----------
+        temperature : float
+            New target temperature, in the units configured on the
+            entity.
+        hvac_mode : str or None, optional
+            HVAC mode to switch to alongside the temperature change.
+        **extra : Any
+            Additional fields forwarded verbatim to Home Assistant
+            (e.g. ``target_temp_high``, ``target_temp_low``).
+        """
         data: dict[str, Any] = {"temperature": float(temperature), **extra}
         if hvac_mode is not None:
             data["hvac_mode"] = hvac_mode
         await self._call_service("set_temperature", data)
 
     async def set_hvac_mode(self, hvac_mode: str) -> None:
-        """Change the HVAC mode (e.g. ``"heat"``, ``"cool"``, ``"off"``)."""
+        """Change the HVAC mode (e.g. ``"heat"``, ``"cool"``, ``"off"``).
+
+        Parameters
+        ----------
+        hvac_mode : str
+            One of the modes reported by `hvac_modes`.
+        """
         await self._call_service("set_hvac_mode", {"hvac_mode": hvac_mode})
 
     async def set_fan_mode(self, fan_mode: str) -> None:
-        """Set the fan mode."""
+        """Set the fan mode.
+
+        Parameters
+        ----------
+        fan_mode : str
+            Fan mode supported by the device (e.g. ``"auto"``,
+            ``"low"``, ``"high"``).
+        """
         await self._call_service("set_fan_mode", {"fan_mode": fan_mode})
 
 

--- a/src/haclient/domains/cover.py
+++ b/src/haclient/domains/cover.py
@@ -20,15 +20,51 @@ class Cover(Entity):
     # -- Listener decorators ------------------------------------------
 
     def on_open(self, func: Any) -> Any:
-        """Register a listener for when the cover opens."""
+        """Register a listener for when the cover opens.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``open`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("open", func)
 
     def on_close(self, func: Any) -> Any:
-        """Register a listener for when the cover closes."""
+        """Register a listener for when the cover closes.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``closed`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("closed", func)
 
     def on_position_change(self, func: Any) -> Any:
-        """Register a listener for position changes."""
+        """Register a listener for position changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new ``current_position`` value
+            (0-100).
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_attr_listener("current_position", func)
 
     # -- State properties ---------------------------------------------
@@ -64,7 +100,14 @@ class Cover(Entity):
         await self._call_service("stop_cover")
 
     async def set_position(self, position: int) -> None:
-        """Set the cover position (0 = closed, 100 = open)."""
+        """Set the cover position (0 = closed, 100 = open).
+
+        Parameters
+        ----------
+        position : int
+            Target position, clamped/coerced to ``int``. ``0`` is fully
+            closed; ``100`` is fully open.
+        """
         await self._call_service("set_cover_position", {"position": int(position)})
 
     async def toggle(self) -> None:

--- a/src/haclient/domains/light.py
+++ b/src/haclient/domains/light.py
@@ -24,23 +24,81 @@ class Light(Entity):
     # -- Listener decorators ------------------------------------------
 
     def on_turn_on(self, func: Any) -> Any:
-        """Register a listener for when the light turns on."""
+        """Register a listener for when the light turns on.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``on`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("on", func)
 
     def on_turn_off(self, func: Any) -> Any:
-        """Register a listener for when the light turns off."""
+        """Register a listener for when the light turns off.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``off`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("off", func)
 
     def on_brightness_change(self, func: Any) -> Any:
-        """Register a listener for brightness changes."""
+        """Register a listener for brightness changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new brightness value (0-255).
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_attr_listener("brightness", func)
 
     def on_color_change(self, func: Any) -> Any:
-        """Register a listener for RGB color changes."""
+        """Register a listener for RGB color changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new ``rgb_color`` value as reported
+            by Home Assistant.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_attr_listener("rgb_color", func)
 
     def on_kelvin_change(self, func: Any) -> Any:
-        """Register a listener for color temperature (Kelvin) changes."""
+        """Register a listener for color temperature (Kelvin) changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new ``color_temp_kelvin`` value.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_attr_listener("color_temp_kelvin", func)
 
     # -- State properties ---------------------------------------------
@@ -85,14 +143,31 @@ class Light(Entity):
     # -- Actions ------------------------------------------------------
 
     async def set_brightness(self, brightness: int, *, transition: float | None = None) -> None:
-        """Set the brightness (0--255), turning the light on if needed."""
+        """Set the brightness (0--255), turning the light on if needed.
+
+        Parameters
+        ----------
+        brightness : int
+            New brightness value, coerced to ``int``. ``0`` turns the
+            light off; ``255`` is full brightness.
+        transition : float or None, optional
+            Seconds for the transition. Forwarded to HA when set.
+        """
         data: dict[str, Any] = {"brightness": int(brightness)}
         if transition is not None:
             data["transition"] = transition
         await self._call_service("turn_on", data)
 
     async def set_kelvin(self, kelvin: int, *, transition: float | None = None) -> None:
-        """Set the color temperature in Kelvin, turning the light on if needed."""
+        """Set the color temperature in Kelvin, turning the light on if needed.
+
+        Parameters
+        ----------
+        kelvin : int
+            Target color temperature in Kelvin.
+        transition : float or None, optional
+            Seconds for the transition. Forwarded to HA when set.
+        """
         data: dict[str, Any] = {"color_temp_kelvin": int(kelvin)}
         if transition is not None:
             data["transition"] = transition
@@ -106,7 +181,19 @@ class Light(Entity):
         *,
         transition: float | None = None,
     ) -> None:
-        """Set the RGB color, turning the light on if needed."""
+        """Set the RGB color, turning the light on if needed.
+
+        Parameters
+        ----------
+        r : int
+            Red component (0-255).
+        g : int
+            Green component (0-255).
+        b : int
+            Blue component (0-255).
+        transition : float or None, optional
+            Seconds for the transition. Forwarded to HA when set.
+        """
         data: dict[str, Any] = {"rgb_color": [r, g, b]}
         if transition is not None:
             data["transition"] = transition
@@ -122,6 +209,15 @@ class Light(Entity):
         """Set the light color by RGB or Kelvin.
 
         Exactly one of *rgb* or *kelvin* must be provided.
+
+        Parameters
+        ----------
+        rgb : tuple of int or None, optional
+            Three-tuple ``(r, g, b)`` with components in 0-255.
+        kelvin : int or None, optional
+            Target color temperature in Kelvin.
+        transition : float or None, optional
+            Seconds for the transition. Forwarded to HA when set.
 
         Raises
         ------
@@ -142,14 +238,26 @@ class Light(Entity):
             await self._call_service("turn_on", data)
 
     async def on(self, *, transition: float | None = None) -> None:
-        """Turn the light on without changing color or brightness."""
+        """Turn the light on without changing color or brightness.
+
+        Parameters
+        ----------
+        transition : float or None, optional
+            Seconds for the transition. Forwarded to HA when set.
+        """
         data: dict[str, Any] = {}
         if transition is not None:
             data["transition"] = transition
         await self._call_service("turn_on", data or None)
 
     async def off(self, *, transition: float | None = None) -> None:
-        """Turn the light off."""
+        """Turn the light off.
+
+        Parameters
+        ----------
+        transition : float or None, optional
+            Seconds for the transition. Forwarded to HA when set.
+        """
         data: dict[str, Any] = {}
         if transition is not None:
             data["transition"] = transition

--- a/src/haclient/domains/media_player.py
+++ b/src/haclient/domains/media_player.py
@@ -206,31 +206,101 @@ class MediaPlayer(Entity):
     # -- Listener decorators ------------------------------------------
 
     def on_volume_change(self, func: Any) -> Any:
-        """Register a listener for volume level changes."""
+        """Register a listener for volume level changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new ``volume_level`` value
+            (``0.0``-``1.0``).
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_attr_listener("volume_level", func)
 
     def on_mute_change(self, func: Any) -> Any:
-        """Register a listener for mute state changes."""
+        """Register a listener for mute state changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new ``is_volume_muted`` value.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_attr_listener("is_volume_muted", func)
 
     def on_media_change(self, func: Any) -> Any:
         """Register a listener for when the playing media changes.
 
         Receives ``(old: NowPlaying, new: NowPlaying)``.
+
+        Parameters
+        ----------
+        func : callable
+            Callable invoked with the previous and current `NowPlaying`
+            snapshots whenever they differ.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
         """
         self._media_change_listeners.append(func)
         return func
 
     def on_play(self, func: Any) -> Any:
-        """Register a listener for when playback starts."""
+        """Register a listener for when playback starts.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``playing`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("playing", func)
 
     def on_pause(self, func: Any) -> Any:
-        """Register a listener for when playback pauses."""
+        """Register a listener for when playback pauses.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``paused`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("paused", func)
 
     def on_stop(self, func: Any) -> Any:
-        """Register a listener for when playback stops."""
+        """Register a listener for when playback stops.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``idle`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("idle", func)
 
     def _dispatch_granular_events(
@@ -250,7 +320,15 @@ class MediaPlayer(Entity):
                 self._schedule_value(listener, old_np, new_np)
 
     def remove_granular_listener(self, func: ValueChangeHandler) -> None:
-        """Remove a granular listener, including media-change listeners."""
+        """Remove a granular listener, including media-change listeners.
+
+        Parameters
+        ----------
+        func : ValueChangeHandler
+            The exact handler previously registered via one of the
+            ``on_*`` listener methods. Unknown handlers are silently
+            ignored.
+        """
         with contextlib.suppress(ValueError):
             self._media_change_listeners.remove(func)
             return
@@ -328,7 +406,13 @@ class MediaPlayer(Entity):
         await self._call_service("volume_set", {"volume_level": float(level)})
 
     async def mute(self, muted: bool = True) -> None:
-        """Mute or unmute the media player."""
+        """Mute or unmute the media player.
+
+        Parameters
+        ----------
+        muted : bool, optional
+            ``True`` to mute (default), ``False`` to unmute.
+        """
         await self._call_service("volume_mute", {"is_volume_muted": bool(muted)})
 
     async def power_on(self) -> None:
@@ -340,7 +424,14 @@ class MediaPlayer(Entity):
         await self._call_service("turn_off")
 
     async def select_source(self, source: str) -> None:
-        """Select an input source."""
+        """Select an input source.
+
+        Parameters
+        ----------
+        source : str
+            Name of the input source. Must be one of the values reported
+            in the entity's ``source_list`` attribute.
+        """
         await self._call_service("select_source", {"source": source})
 
     async def play_media(
@@ -349,7 +440,18 @@ class MediaPlayer(Entity):
         media_content_id: str,
         **extra: Any,
     ) -> None:
-        """Play a specific media item."""
+        """Play a specific media item.
+
+        Parameters
+        ----------
+        media_content_type : str
+            Media content type identifier (e.g. ``"music"``).
+        media_content_id : str
+            Media content id understood by the underlying integration.
+        **extra : Any
+            Additional fields forwarded verbatim to Home Assistant
+            (e.g. ``enqueue``, ``announce``).
+        """
         data: dict[str, Any] = {
             "media_content_type": media_content_type,
             "media_content_id": media_content_id,
@@ -363,6 +465,15 @@ class MediaPlayer(Entity):
         media_content_id: str | None = None,
     ) -> dict[str, Any]:
         """Issue a single ``media_player/browse_media`` WebSocket command.
+
+        Parameters
+        ----------
+        media_content_type : str or None, optional
+            Restrict browsing to this content type. ``None`` returns the
+            root browse node.
+        media_content_id : str or None, optional
+            Restrict browsing to this content id. ``None`` returns the
+            root browse node.
 
         Returns
         -------

--- a/src/haclient/domains/scene.py
+++ b/src/haclient/domains/scene.py
@@ -71,7 +71,14 @@ class Scene(Entity):
     # -- Actions ------------------------------------------------------
 
     async def activate(self, *, transition: float | None = None) -> None:
-        """Activate the scene."""
+        """Activate the scene.
+
+        Parameters
+        ----------
+        transition : float or None, optional
+            Seconds over which entities supporting transitions should
+            move to their scene state.
+        """
         data: dict[str, Any] | None = None
         if transition is not None:
             data = {"transition": transition}
@@ -84,7 +91,19 @@ class Scene(Entity):
     # -- Listener decorators ------------------------------------------
 
     def on_activate(self, func: Any) -> Any:
-        """Register a listener that fires when the scene is activated."""
+        """Register a listener that fires when the scene is activated.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async callable receiving the new ``state`` value
+            (the ISO-8601 activation timestamp).
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_value_listener(func)
 
 

--- a/src/haclient/domains/sensor.py
+++ b/src/haclient/domains/sensor.py
@@ -24,6 +24,16 @@ class Sensor(Entity):
         """Register a listener for sensor value changes.
 
         Receives the **state strings** directly (e.g. ``"21.5"``).
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async callable receiving the new state string.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
         """
         return self._register_state_value_listener(func)
 

--- a/src/haclient/domains/switch.py
+++ b/src/haclient/domains/switch.py
@@ -21,11 +21,35 @@ class Switch(Entity):
     # -- Listener decorators ------------------------------------------
 
     def on_turn_on(self, func: Any) -> Any:
-        """Register a listener for when the switch turns on."""
+        """Register a listener for when the switch turns on.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``on`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("on", func)
 
     def on_turn_off(self, func: Any) -> Any:
-        """Register a listener for when the switch turns off."""
+        """Register a listener for when the switch turns off.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``off`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("off", func)
 
     # -- State properties ---------------------------------------------

--- a/src/haclient/domains/timer.py
+++ b/src/haclient/domains/timer.py
@@ -176,7 +176,14 @@ class Timer(Entity):
     # -- Actions ------------------------------------------------------
 
     async def start(self, *, duration: str | None = None) -> None:
-        """Start (or restart) the timer."""
+        """Start (or restart) the timer.
+
+        Parameters
+        ----------
+        duration : str or None, optional
+            Optional override duration in HA format (e.g. ``"00:05:00"``).
+            ``None`` keeps the helper's configured duration.
+        """
         data: dict[str, Any] | None = {"duration": duration} if duration else None
         await self._call_service("start", data)
 
@@ -193,27 +200,81 @@ class Timer(Entity):
         await self._call_service("finish")
 
     async def change(self, *, duration: str) -> None:
-        """Add or subtract time from a running timer."""
+        """Add or subtract time from a running timer.
+
+        Parameters
+        ----------
+        duration : str
+            Signed HA duration string (e.g. ``"00:01:00"`` to add a
+            minute, ``"-00:00:30"`` to subtract 30 seconds).
+        """
         await self._call_service("change", {"duration": duration})
 
     # -- Listener decorators ------------------------------------------
 
     def on_start(self, func: Any) -> Any:
-        """Register a listener for when the timer starts (becomes active)."""
+        """Register a listener for when the timer starts (becomes active).
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``active`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("active", func)
 
     def on_pause(self, func: Any) -> Any:
-        """Register a listener for when the timer is paused."""
+        """Register a listener for when the timer is paused.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``paused`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("paused", func)
 
     def on_idle(self, func: Any) -> Any:
-        """Register a listener for when the timer becomes idle."""
+        """Register a listener for when the timer becomes idle.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``idle`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
         return self._register_state_transition_listener("idle", func)
 
     def on_finished(self, func: Any) -> Any:
         """Register a listener for natural timer expiry.
 
         Driven by the HA ``timer.finished`` event (not state changes).
+
+        Parameters
+        ----------
+        func : callable
+            Callable invoked with ``(entity_id, event_data)`` when the
+            timer expires.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
         """
         self._finished_listeners.append(func)
         return func
@@ -222,6 +283,17 @@ class Timer(Entity):
         """Register a listener for explicit timer cancellation.
 
         Driven by the HA ``timer.cancelled`` event (not state changes).
+
+        Parameters
+        ----------
+        func : callable
+            Callable invoked with ``(entity_id, event_data)`` when the
+            timer is cancelled.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
         """
         self._cancelled_listeners.append(func)
         return func
@@ -329,6 +401,12 @@ def _parse_duration_to_seconds(value: str) -> float | None:
     """Parse a Home Assistant duration string to total seconds.
 
     Supports formats like ``"0:05:00"`` and ``"00:05:00"``.
+
+    Parameters
+    ----------
+    value : str
+        Duration string in ``"H:MM:SS"`` or ``"HH:MM:SS"`` form. Seconds
+        may include a fractional component.
 
     Returns
     -------

--- a/src/haclient/entity/base.py
+++ b/src/haclient/entity/base.py
@@ -65,6 +65,12 @@ class Entity:
         Current state string.
     attributes : dict
         Current entity attributes from Home Assistant.
+
+    Raises
+    ------
+    ValueError
+        If *entity_id* is not fully qualified (i.e. lacks a domain
+        prefix like ``"light."``).
     """
 
     domain: ClassVar[str] = ""
@@ -200,7 +206,18 @@ class Entity:
         return func
 
     def remove_granular_listener(self, func: ValueChangeHandler) -> None:
-        """Remove a previously registered granular listener."""
+        """Remove a previously registered granular listener.
+
+        Searches attribute listeners, state-transition listeners, and
+        state-value listeners (in that order) for *func* and removes the
+        first match. Unknown handlers are silently ignored.
+
+        Parameters
+        ----------
+        func : ValueChangeHandler
+            The exact handler previously registered via one of the
+            ``on_*`` listener methods.
+        """
         for listeners in self._attr_listeners.values():
             with contextlib.suppress(ValueError):
                 listeners.remove(func)
@@ -213,12 +230,33 @@ class Entity:
             self._state_value_listeners.remove(func)
 
     def on_state_change(self, func: F) -> F:
-        """Register *func* as a listener for raw state changes."""
+        """Register *func* as a listener for raw state changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable invoked with ``(old_state_dict, new_state_dict)``
+            on every ``state_changed`` event for this entity. May be
+            sync or async.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned so the method can be used as a
+            decorator.
+        """
         self._listeners.append(func)
         return func
 
     def remove_listener(self, func: StateChangeHandler) -> None:
-        """Remove a previously registered state change listener."""
+        """Remove a previously registered state change listener.
+
+        Parameters
+        ----------
+        func : StateChangeHandler
+            The exact handler previously passed to `on_state_change`.
+            Unknown handlers are silently ignored.
+        """
         with contextlib.suppress(ValueError):
             self._listeners.remove(func)
 

--- a/src/haclient/infra/rest_aiohttp.py
+++ b/src/haclient/infra/rest_aiohttp.py
@@ -140,7 +140,15 @@ class AiohttpRestAdapter:
             raise HAClientError(f"HTTP request failed: {err}") from err
 
     async def ping(self) -> bool:
-        """Verify Home Assistant is reachable."""
+        """Verify Home Assistant is reachable.
+
+        Returns
+        -------
+        bool
+            ``True`` if the ``/api/`` endpoint responded successfully.
+            Failures surface as exceptions from `_request`; this method
+            never returns ``False``.
+        """
         await self._request("GET", "/api/")
         return True
 

--- a/src/haclient/infra/ws_aiohttp.py
+++ b/src/haclient/infra/ws_aiohttp.py
@@ -168,12 +168,39 @@ class AiohttpWebSocketAdapter:
             await self._session.close()
 
     def on_disconnect(self, handler: DisconnectListener) -> DisconnectListener:
-        """Register a disconnect listener."""
+        """Register a disconnect listener.
+
+        Parameters
+        ----------
+        handler : DisconnectListener
+            Sync or async zero-argument callable invoked when the
+            WebSocket connection drops.
+
+        Returns
+        -------
+        DisconnectListener
+            The same *handler*, returned so the method can be used as a
+            decorator.
+        """
         self._disconnect_listeners.append(handler)
         return handler
 
     def on_reconnect(self, handler: ReconnectListener) -> ReconnectListener:
-        """Register a reconnect listener."""
+        """Register a reconnect listener.
+
+        Parameters
+        ----------
+        handler : ReconnectListener
+            Sync or async zero-argument callable invoked after the
+            WebSocket reconnects and prior subscriptions have been
+            re-established.
+
+        Returns
+        -------
+        ReconnectListener
+            The same *handler*, returned so the method can be used as a
+            decorator.
+        """
         self._reconnect_listeners.append(handler)
         return handler
 
@@ -207,7 +234,33 @@ class AiohttpWebSocketAdapter:
         *,
         timeout: float | None = None,
     ) -> Any:
-        """Send a command and await its ``result`` frame."""
+        """Send a command and await its ``result`` frame.
+
+        An ``id`` field is injected automatically; callers must not set
+        it themselves.
+
+        Parameters
+        ----------
+        payload : dict
+            Command body without an ``id`` field.
+        timeout : float or None, optional
+            Seconds to wait for the matching ``result`` frame. ``None``
+            uses the adapter's configured ``request_timeout``.
+
+        Returns
+        -------
+        Any
+            The ``result`` field of the response frame.
+
+        Raises
+        ------
+        ConnectionClosedError
+            If the WebSocket is not currently connected.
+        TimeoutError
+            If no matching ``result`` arrives within *timeout*.
+        CommandError
+            If Home Assistant responds with ``success=False``.
+        """
         if not self.connected:
             raise ConnectionClosedError("WebSocket is not connected")
         assert self._ws is not None
@@ -233,7 +286,24 @@ class AiohttpWebSocketAdapter:
         handler: EventHandler,
         event_type: str | None = None,
     ) -> int:
-        """Subscribe to Home Assistant events."""
+        """Subscribe to Home Assistant events.
+
+        Subscriptions are remembered so they can be re-established
+        automatically on reconnect.
+
+        Parameters
+        ----------
+        handler : callable
+            Sync or async callable invoked with each matching event.
+        event_type : str or None, optional
+            Restrict the subscription to a single event type. ``None``
+            subscribes to all events.
+
+        Returns
+        -------
+        int
+            The subscription id, suitable for passing to `unsubscribe`.
+        """
         payload: dict[str, Any] = {"type": "subscribe_events"}
         if event_type is not None:
             payload["event_type"] = event_type
@@ -257,7 +327,15 @@ class AiohttpWebSocketAdapter:
         return cmd_id
 
     async def unsubscribe(self, subscription_id: int) -> None:
-        """Cancel a previously registered subscription."""
+        """Cancel a previously registered subscription.
+
+        Parameters
+        ----------
+        subscription_id : int
+            The id returned by `subscribe_events`. Unknown ids are
+            silently ignored on the local side; HA may still return an
+            error.
+        """
         await self.send_command({"type": "unsubscribe_events", "subscription": subscription_id})
         self._subscriptions.pop(subscription_id, None)
         for k, (sid, _handler) in list(self._event_subs.items()):
@@ -398,7 +476,21 @@ class AiohttpWebSocketAdapter:
             return
 
     async def ping(self, *, timeout: float | None = None) -> None:
-        """Send a ``ping`` frame and wait for the matching ``pong``."""
+        """Send a ``ping`` frame and wait for the matching ``pong``.
+
+        Parameters
+        ----------
+        timeout : float or None, optional
+            Seconds to wait for the pong. ``None`` uses the adapter's
+            configured ``request_timeout``.
+
+        Raises
+        ------
+        ConnectionClosedError
+            If the WebSocket is not currently connected.
+        TimeoutError
+            If the pong does not arrive within *timeout*.
+        """
         if not self.connected:
             raise ConnectionClosedError("WebSocket is not connected")
         assert self._ws is not None

--- a/src/haclient/sync.py
+++ b/src/haclient/sync.py
@@ -187,7 +187,38 @@ class SyncHAClient:
         domains: list[str] | None = None,
         load_plugins: bool = True,
     ) -> SyncHAClient:
-        """Build a `SyncHAClient` from a base URL and token."""
+        """Build a `SyncHAClient` from a base URL and token.
+
+        Parameters
+        ----------
+        base_url : str
+            Home Assistant base URL.
+        token : str
+            Long-lived access token.
+        ws_url : str or None, optional
+            Explicit WebSocket URL (derived from *base_url* when omitted).
+        reconnect : bool, optional
+            Whether the WebSocket should reconnect automatically.
+        ping_interval : float, optional
+            Seconds between WebSocket keepalive pings.
+        request_timeout : float, optional
+            Default timeout for individual requests.
+        verify_ssl : bool, optional
+            Verify TLS certificates.
+        service_policy : ServicePolicy, optional
+            Default service-call routing policy.
+        domains : list of str or None, optional
+            Restrict loaded domains. ``None`` loads all registered
+            domains.
+        load_plugins : bool, optional
+            Discover third-party plugins via the ``haclient.domains``
+            entry-point group.
+
+        Returns
+        -------
+        SyncHAClient
+            The configured sync client (not yet connected).
+        """
         config = ConnectionConfig.from_url(
             base_url,
             token,
@@ -230,47 +261,161 @@ class SyncHAClient:
     def on_reconnect(
         self, handler: Callable[[], Awaitable[None] | None]
     ) -> Callable[[], Awaitable[None] | None]:
-        """Register a reconnect listener."""
+        """Register a reconnect listener.
+
+        Parameters
+        ----------
+        handler : callable
+            Sync or async zero-argument callable invoked after the
+            WebSocket reconnects.
+
+        Returns
+        -------
+        callable
+            The same *handler*, returned so the method can be used as a
+            decorator.
+        """
         return self._client.on_reconnect(handler)
 
     def on_disconnect(
         self, handler: Callable[[], Awaitable[None] | None]
     ) -> Callable[[], Awaitable[None] | None]:
-        """Register a disconnect listener."""
+        """Register a disconnect listener.
+
+        Parameters
+        ----------
+        handler : callable
+            Sync or async zero-argument callable invoked when the
+            WebSocket connection drops.
+
+        Returns
+        -------
+        callable
+            The same *handler*, returned so the method can be used as a
+            decorator.
+        """
         return self._client.on_disconnect(handler)
 
     # -- Domain accessors --
 
     def domain(self, name: str) -> _SyncDomainAccessor:
-        """Return a sync accessor for *name*."""
+        """Return a sync accessor for *name*.
+
+        Parameters
+        ----------
+        name : str
+            HA domain name (e.g. ``"light"`` or a third-party domain).
+
+        Returns
+        -------
+        _SyncDomainAccessor
+            Blocking accessor wrapping the underlying async accessor.
+        """
         return _SyncDomainAccessor(self._client.domain(name), self._loop_thread)
 
     def media_player(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `MediaPlayer`."""
+        """Return a sync proxy wrapping the async `MediaPlayer`.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name or full ``media_player.<name>`` id.
+
+        Returns
+        -------
+        _SyncProxy
+            Blocking proxy delegating to the async `MediaPlayer`.
+        """
         return _SyncProxy(self._client.media_player(name), self._loop_thread)
 
     def light(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Light`."""
+        """Return a sync proxy wrapping the async `Light`.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name or full ``light.<name>`` id.
+
+        Returns
+        -------
+        _SyncProxy
+            Blocking proxy delegating to the async `Light`.
+        """
         return _SyncProxy(self._client.light(name), self._loop_thread)
 
     def switch(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Switch`."""
+        """Return a sync proxy wrapping the async `Switch`.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name or full ``switch.<name>`` id.
+
+        Returns
+        -------
+        _SyncProxy
+            Blocking proxy delegating to the async `Switch`.
+        """
         return _SyncProxy(self._client.switch(name), self._loop_thread)
 
     def climate(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Climate`."""
+        """Return a sync proxy wrapping the async `Climate`.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name or full ``climate.<name>`` id.
+
+        Returns
+        -------
+        _SyncProxy
+            Blocking proxy delegating to the async `Climate`.
+        """
         return _SyncProxy(self._client.climate(name), self._loop_thread)
 
     def cover(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Cover`."""
+        """Return a sync proxy wrapping the async `Cover`.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name or full ``cover.<name>`` id.
+
+        Returns
+        -------
+        _SyncProxy
+            Blocking proxy delegating to the async `Cover`.
+        """
         return _SyncProxy(self._client.cover(name), self._loop_thread)
 
     def sensor(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Sensor`."""
+        """Return a sync proxy wrapping the async `Sensor`.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name or full ``sensor.<name>`` id.
+
+        Returns
+        -------
+        _SyncProxy
+            Blocking proxy delegating to the async `Sensor`.
+        """
         return _SyncProxy(self._client.sensor(name), self._loop_thread)
 
     def binary_sensor(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `BinarySensor`."""
+        """Return a sync proxy wrapping the async `BinarySensor`.
+
+        Parameters
+        ----------
+        name : str
+            Short entity name or full ``binary_sensor.<name>`` id.
+
+        Returns
+        -------
+        _SyncProxy
+            Blocking proxy delegating to the async `BinarySensor`.
+        """
         return _SyncProxy(self._client.binary_sensor(name), self._loop_thread)
 
     @property


### PR DESCRIPTION
## Summary

Closes the documentation gap surfaced by an audit against the AGENTS.md docstring convention. The public API surface relied heavily on one-liner docstrings without `Parameters`/`Returns`/`Raises` sections, which AGENTS.md requires for public methods.

## Changes

- **CRITICAL** Documented `EntityFactoryProtocol.get_or_create` and `in_domain` (previously had no docstrings at all).
- **IMPORTANT** Added Parameters/Returns/Raises sections to ~75 public methods:
  - `HAClient` and `SyncHAClient` listener registrations and entity accessors.
  - `Connection.on_disconnect` / `on_reconnect` (and the WS adapter equivalents).
  - `EventBus.unsubscribe` and `install_reconnect_hook`.
  - `DomainRegistry.get` and `filter`.
  - All domain `on_*` listener methods (binary_sensor, climate, cover, light, media_player, scene, sensor, switch, timer).
  - Domain action methods that take parameters (`set_temperature`, `set_position`, `set_brightness`, `play_media`, `browse_media`, `Timer.start`/`change`, etc.).
  - `Entity.on_state_change`, `remove_listener`, `remove_granular_listener` (+ `__init__` `Raises`).
  - Infra adapters: `AiohttpRestAdapter.ping`, `AiohttpWebSocketAdapter.send_command` / `subscribe_events` / `unsubscribe` / `ping` / `on_disconnect` / `on_reconnect`.
  - `_parse_duration_to_seconds` Parameters section.

No behavior changes — purely docstring additions.

## Verification

- `pytest tests/ --cov=haclient --cov-fail-under=95` — 248 passed, 96.45% coverage.
- `ruff check src tests` — clean.
- `ruff format --check src tests` — clean.
- `mypy src` — clean.