### PR TITLE
Document test infrastructure and reusable test helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,15 @@ from .fake_ha import FakeHA
 
 @pytest_asyncio.fixture
 async def fake_ha() -> AsyncIterator[FakeHA]:
-    """Start a `FakeHA` server and tear it down after the test."""
+    """Start a `FakeHA` server and tear it down after the test.
+
+    Yields
+    ------
+    FakeHA
+        A running in-process server bound to a free local port. Tests
+        may register custom command handlers via ``server.handlers`` or
+        push events with ``server.push_event``.
+    """
     server = FakeHA()
     await server.start()
     try:
@@ -25,7 +33,19 @@ async def fake_ha() -> AsyncIterator[FakeHA]:
 
 @pytest_asyncio.fixture
 async def client(fake_ha: FakeHA) -> AsyncIterator[HAClient]:
-    """Return a connected `HAClient` talking to the fake server."""
+    """Return a connected `HAClient` talking to the fake server.
+
+    Parameters
+    ----------
+    fake_ha : FakeHA
+        Active fake server provided by the `fake_ha` fixture.
+
+    Yields
+    ------
+    HAClient
+        Connected client. ``ping_interval`` is disabled and the request
+        timeout is shortened to keep the test suite snappy.
+    """
     ha = HAClient.from_url(
         fake_ha.base_url,
         token=fake_ha.token,
@@ -41,4 +61,11 @@ async def client(fake_ha: FakeHA) -> AsyncIterator[HAClient]:
 
 @pytest.fixture
 def anyio_backend() -> str:
+    """Force the ``anyio`` plugin to run on the asyncio backend.
+
+    Returns
+    -------
+    str
+        The backend identifier consumed by ``pytest-anyio``.
+    """
     return "asyncio"

--- a/tests/fake_ha.py
+++ b/tests/fake_ha.py
@@ -22,7 +22,43 @@ CommandHandler = Callable[["FakeHA", web.WebSocketResponse, dict[str, Any]], Awa
 
 
 class FakeHA:
-    """Run an aiohttp server exposing a subset of the HA HTTP + WS API."""
+    """Run an aiohttp server exposing a subset of the HA HTTP + WS API.
+
+    The server binds to ``127.0.0.1`` on a free OS-assigned port. Tests
+    interact with it as a black box via `base_url` / `ws_url` and may
+    customise behaviour by mutating the public attributes below.
+
+    Attributes
+    ----------
+    token : str
+        Bearer token accepted on REST requests and the WS auth
+        handshake.
+    require_auth : bool
+        When ``False``, REST endpoints skip the token check.
+    states : list of dict
+        State dicts returned by ``GET /api/states`` and
+        ``GET /api/states/<entity_id>``. Tests may mutate this list at
+        any time.
+    handlers : dict
+        Optional per-command-type overrides. When set, the handler is
+        invoked instead of the built-in dispatch logic.
+    rest_service_calls : list of tuple
+        Recorded ``(domain, service, payload)`` triples for every
+        ``POST /api/services/...`` call.
+    ws_service_calls : list of dict
+        Recorded payloads for every ``call_service`` WS command.
+    subscriptions : dict
+        Map of event type to subscription ids per current connection.
+    reject_auth : bool
+        When ``True``, the WS auth handshake responds with
+        ``auth_invalid`` regardless of the supplied token.
+    drop_on_command : str or None
+        When set, the WS connection is closed without responding the
+        first time a command of this ``type`` arrives. Useful to
+        simulate mid-flight disconnects.
+    port : int
+        Bound TCP port (set by `start`).
+    """
 
     def __init__(
         self,
@@ -31,6 +67,18 @@ class FakeHA:
         require_auth: bool = True,
         states: list[dict[str, Any]] | None = None,
     ) -> None:
+        """Initialise the fake server.
+
+        Parameters
+        ----------
+        token : str, optional
+            Bearer token accepted by the server.
+        require_auth : bool, optional
+            When ``False``, REST endpoints skip the token check.
+        states : list of dict or None, optional
+            Initial state objects returned by the ``/api/states``
+            endpoints.
+        """
         self.token = token
         self.require_auth = require_auth
         self.states: list[dict[str, Any]] = states or []
@@ -56,6 +104,13 @@ class FakeHA:
         self.drop_on_command: str | None = None
 
     async def start(self) -> str:
+        """Bind to a free port and start serving.
+
+        Returns
+        -------
+        str
+            The base URL (``http://127.0.0.1:<port>``).
+        """
         self._runner = web.AppRunner(self._app)
         await self._runner.setup()
         self._site = web.TCPSite(self._runner, "127.0.0.1", 0)
@@ -66,6 +121,7 @@ class FakeHA:
         return f"http://127.0.0.1:{self.port}"
 
     async def stop(self) -> None:
+        """Close all open WS connections and shut down the HTTP runner."""
         for ws in list(self.connections):
             if not ws.closed:
                 await ws.close()
@@ -76,13 +132,23 @@ class FakeHA:
 
     @property
     def base_url(self) -> str:
+        """Return the bound HTTP base URL."""
         return f"http://127.0.0.1:{self.port}"
 
     @property
     def ws_url(self) -> str:
+        """Return the bound WebSocket URL."""
         return f"ws://127.0.0.1:{self.port}/api/websocket"
 
     def _check_token(self, request: web.Request) -> web.Response | None:
+        """Validate the bearer token on a REST request.
+
+        Returns
+        -------
+        web.Response or None
+            A 401 response when the token is missing or wrong; ``None``
+            when the request is authorised (or auth is disabled).
+        """
         if not self.require_auth:
             return None
         header = request.headers.get("Authorization", "")
@@ -91,18 +157,24 @@ class FakeHA:
         return None
 
     async def _handle_ping(self, request: web.Request) -> web.Response:
+        """Handle ``GET /api/`` (the HA reachability probe)."""
         denial = self._check_token(request)
         if denial is not None:
             return denial
         return web.json_response({"message": "API running."})
 
     async def _handle_states(self, request: web.Request) -> web.Response:
+        """Handle ``GET /api/states`` by returning every known state."""
         denial = self._check_token(request)
         if denial is not None:
             return denial
         return web.json_response(self.states)
 
     async def _handle_state(self, request: web.Request) -> web.Response:
+        """Handle ``GET /api/states/<entity_id>``.
+
+        Returns 404 when the entity is not in `states`.
+        """
         denial = self._check_token(request)
         if denial is not None:
             return denial
@@ -113,6 +185,11 @@ class FakeHA:
         return web.Response(status=404, text="not found")
 
     async def _handle_service(self, request: web.Request) -> web.Response:
+        """Handle ``POST /api/services/<domain>/<service>``.
+
+        Records the call into `rest_service_calls` and returns an empty
+        list, matching HA's "no states changed" response shape.
+        """
         denial = self._check_token(request)
         if denial is not None:
             return denial
@@ -126,6 +203,12 @@ class FakeHA:
         return web.json_response([])
 
     async def _handle_ws(self, request: web.Request) -> web.WebSocketResponse:
+        """Drive the full WebSocket lifecycle for a single connection.
+
+        Performs the HA auth handshake (``auth_required`` →
+        ``auth_invalid``/``auth_ok``) and then dispatches every
+        subsequent text frame through `_dispatch` until the peer closes.
+        """
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         self.connections.append(ws)
@@ -153,6 +236,27 @@ class FakeHA:
         return ws
 
     async def _dispatch(self, ws: web.WebSocketResponse, msg: dict[str, Any]) -> None:
+        """Route an incoming WS command to the appropriate handler.
+
+        Resolution order:
+
+        1. If `drop_on_command` matches, close the socket and return.
+        2. If a per-type handler is registered in `handlers`, invoke it.
+        3. Otherwise, fall through to the built-in handlers for the
+           commands actually exercised by the test suite (``ping``,
+           ``subscribe_events``, ``unsubscribe_events``, ``call_service``,
+           ``media_player/browse_media``, ``timer/create``,
+           ``timer/delete``).
+        4. Unknown command types receive an ``unknown_command`` error
+           response.
+
+        Parameters
+        ----------
+        ws : web.WebSocketResponse
+            The connection to reply on.
+        msg : dict
+            The decoded command frame.
+        """
         mtype = msg.get("type", "")
         mid = msg.get("id")
 

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -13,6 +13,26 @@ from .fake_ha import FakeHA
 
 
 def _find_call(fake_ha: FakeHA, service: str) -> dict[str, Any]:
+    """Return the first WS ``call_service`` payload for *service*.
+
+    Parameters
+    ----------
+    fake_ha : FakeHA
+        The fake server whose `ws_service_calls` log to search.
+    service : str
+        The service name to match (e.g. ``"turn_on"``).
+
+    Returns
+    -------
+    dict
+        The recorded payload.
+
+    Raises
+    ------
+    AssertionError
+        If no matching call is found, so that test failures point at
+        the missing service rather than indexing on an empty result.
+    """
     for call in fake_ha.ws_service_calls:
         if call["service"] == service:
             return call

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -20,6 +20,7 @@ class _FakeWS:
     """
 
     def __init__(self) -> None:
+        """Initialise empty subscription / listener tracking state."""
         self.connected_flag: bool = True
         self.subscriptions: dict[int, tuple[str | None, Any]] = {}
         self.next_id = 0
@@ -30,16 +31,25 @@ class _FakeWS:
 
     @property
     def connected(self) -> bool:
+        """Return ``True`` while the simulated socket is open."""
         return self.connected_flag
 
-    async def connect(self) -> None: ...
+    async def connect(self) -> None:
+        """Stub: no-op connect to satisfy the `WebSocketPort` protocol."""
 
-    async def close(self) -> None: ...
+    async def close(self) -> None:
+        """Stub: no-op close to satisfy the `WebSocketPort` protocol."""
 
     async def send_command(self, payload: dict[str, Any], *, timeout: float | None = None) -> Any:
+        """Stub: ignore commands and return ``None``."""
         return None
 
     async def subscribe_events(self, handler: Any, event_type: str | None = None) -> int:
+        """Record a subscription and return a fresh id.
+
+        Setting `subscribe_failure` causes this to raise; tests use that
+        to exercise error paths.
+        """
         if self.subscribe_failure is not None:
             raise self.subscribe_failure
         self.next_id += 1
@@ -47,18 +57,33 @@ class _FakeWS:
         return self.next_id
 
     async def unsubscribe(self, subscription_id: int) -> None:
+        """Forget a subscription and record the id for assertions."""
         self.unsubscribed.append(subscription_id)
         self.subscriptions.pop(subscription_id, None)
 
     def on_disconnect(self, handler: Any) -> Any:
+        """Record a disconnect listener and return it."""
         self.disconnect_listeners.append(handler)
         return handler
 
     def on_reconnect(self, handler: Any) -> Any:
+        """Record a reconnect listener and return it."""
         self.reconnect_listeners.append(handler)
         return handler
 
     async def push(self, event_type: str, event: dict[str, Any]) -> None:
+        """Deliver *event* to every handler subscribed to *event_type*.
+
+        Used by tests to drive `EventBus` from outside without a real
+        WebSocket transport. Awaitable handlers are awaited.
+
+        Parameters
+        ----------
+        event_type : str
+            Event type whose subscribers should receive *event*.
+        event : dict
+            The event payload as it would arrive over the WS.
+        """
         for et, handler in self.subscriptions.values():
             if et == event_type:
                 result = handler(event)

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -12,7 +12,15 @@ from .fake_ha import FakeHA
 
 
 def _make_tree() -> dict[str, Any]:
-    """Return a multi-level browse_media root used by the browse handler."""
+    """Return a multi-level browse_media root used by the browse handler.
+
+    Returns
+    -------
+    dict
+        A synthetic root browse node containing an expandable
+        ``Favorites`` directory and two playable tracks (one
+        intentionally duplicated to exercise dedup).
+    """
     return {
         "title": "root",
         "media_content_id": "root",
@@ -46,6 +54,12 @@ def _make_tree() -> dict[str, Any]:
 
 
 def _make_subtree() -> dict[str, Any]:
+    """Return the ``Favorites`` subtree returned for ``media_content_id="favs"``.
+
+    Includes a malformed entry (missing ``media_content_id``) and a raw
+    string in ``children`` to exercise robustness of the favorites
+    walker.
+    """
     return {
         "title": "Favorites",
         "media_content_id": "favs",
@@ -72,6 +86,7 @@ def _make_subtree() -> dict[str, Any]:
 
 
 def _make_playlist_a() -> dict[str, Any]:
+    """Return the ``Playlist A`` subtree containing two playable tracks."""
     return {
         "title": "Playlist A",
         "media_content_id": "playlist://a",
@@ -98,6 +113,22 @@ def _make_playlist_a() -> dict[str, Any]:
 
 
 async def _browse_handler(server: FakeHA, ws: web.WebSocketResponse, msg: dict[str, Any]) -> None:
+    """`FakeHA` handler that serves the staged ``browse_media`` tree.
+
+    Routes ``media_content_id`` to one of the ``_make_*`` builders and
+    replies with a ``success=True`` result frame. Unknown ids return an
+    empty ``children`` list to keep the recursion bounded.
+
+    Parameters
+    ----------
+    server : FakeHA
+        Server hosting the WebSocket; unused but required by the
+        `CommandHandler` signature.
+    ws : web.WebSocketResponse
+        Connection on which to send the reply.
+    msg : dict
+        The decoded ``media_player/browse_media`` command.
+    """
     content_id = msg.get("media_content_id")
     if content_id is None:
         result = _make_tree()
@@ -245,6 +276,7 @@ def _make_sonos_root() -> dict[str, Any]:
 
 
 def _make_sonos_radio() -> dict[str, Any]:
+    """Return the ``Radio`` subtree of the synthetic Sonos favorites."""
     return {
         "title": "Radio",
         "media_class": "directory",
@@ -275,6 +307,7 @@ def _make_sonos_radio() -> dict[str, Any]:
 
 
 def _make_sonos_albums() -> dict[str, Any]:
+    """Return the ``Albums`` subtree of the synthetic Sonos favorites."""
     return {
         "title": "Albums",
         "media_class": "directory",
@@ -296,6 +329,7 @@ def _make_sonos_albums() -> dict[str, Any]:
 
 
 def _make_sonos_playlists() -> dict[str, Any]:
+    """Return the ``Playlists`` subtree of the synthetic Sonos favorites."""
     return {
         "title": "Playlists",
         "media_class": "directory",
@@ -319,6 +353,20 @@ def _make_sonos_playlists() -> dict[str, Any]:
 async def _sonos_browse_handler(
     server: FakeHA, ws: web.WebSocketResponse, msg: dict[str, Any]
 ) -> None:
+    """`FakeHA` handler that serves the synthetic Sonos favorites tree.
+
+    Parameters
+    ----------
+    server : FakeHA
+        Server hosting the WebSocket; unused but required by the
+        `CommandHandler` signature.
+    ws : web.WebSocketResponse
+        Connection on which to send the reply.
+    msg : dict
+        The decoded ``media_player/browse_media`` command. The
+        ``media_content_id`` selects which subtree builder is invoked;
+        unknown ids resolve to an empty ``children`` list.
+    """
     content_id = msg.get("media_content_id")
     if content_id is None or content_id == "":
         result = _make_sonos_root()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -14,9 +14,12 @@ from haclient.exceptions import HAClientError
 
 
 class _Custom(Entity):
+    """Tiny custom-domain `Entity` used as a registration fixture."""
+
     domain = "custom_domain"
 
     async def fire(self) -> None:
+        """Issue a no-op service call so the test can assert routing."""
         await self._call_service("noop")
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -11,15 +11,20 @@ from haclient.exceptions import ConnectionClosedError
 
 
 class _FakeRest:
+    """`RestPort` stub that records every ``call_service`` invocation."""
+
     base_url = "http://x"
 
     def __init__(self) -> None:
+        """Initialise the (domain, service, data) call log."""
         self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
 
     async def get_states(self) -> list[dict[str, Any]]:
+        """Stub: return no states."""
         return []
 
     async def get_state(self, entity_id: str) -> dict[str, Any] | None:
+        """Stub: return ``None`` for every entity."""
         return None
 
     async def call_service(
@@ -28,38 +33,58 @@ class _FakeRest:
         service: str,
         data: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
+        """Record the call and return an empty state list."""
         self.calls.append((domain, service, data))
         return []
 
-    async def close(self) -> None: ...
+    async def close(self) -> None:
+        """Stub: no resources to release."""
 
 
 class _FakeWS:
+    """`WebSocketPort` stub that records every command sent through it."""
+
     def __init__(self, *, connected: bool = True) -> None:
+        """Initialise the connection flag and command log.
+
+        Parameters
+        ----------
+        connected : bool, optional
+            Initial value for `connected`. Tests use ``False`` to
+            simulate a closed socket.
+        """
         self._connected = connected
         self.commands: list[dict[str, Any]] = []
 
     @property
     def connected(self) -> bool:
+        """Return the configured connection flag."""
         return self._connected
 
-    async def connect(self) -> None: ...
+    async def connect(self) -> None:
+        """Stub: no-op connect."""
 
-    async def close(self) -> None: ...
+    async def close(self) -> None:
+        """Stub: no-op close."""
 
     async def send_command(self, payload: dict[str, Any], *, timeout: float | None = None) -> Any:
+        """Record *payload* and return a fixed ``"ws-result"`` token."""
         self.commands.append(payload)
         return "ws-result"
 
     async def subscribe_events(self, handler: Any, event_type: str | None = None) -> int:
+        """Stub: return a fixed subscription id of ``0``."""
         return 0
 
-    async def unsubscribe(self, subscription_id: int) -> None: ...
+    async def unsubscribe(self, subscription_id: int) -> None:
+        """Stub: no-op unsubscribe."""
 
     def on_disconnect(self, handler: Any) -> Any:
+        """Stub: return *handler* unchanged."""
         return handler
 
     def on_reconnect(self, handler: Any) -> Any:
+        """Stub: return *handler* unchanged."""
         return handler
 
 

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -10,54 +10,79 @@ from haclient.exceptions import HAClientError
 
 
 class _Rest:
+    """`RestPort` stub used to drive `StateStore` priming edge cases."""
+
     base_url = "http://x"
 
     def __init__(self, *, raise_on_get_states: bool = False, states: list[Any] | None = None):
+        """Configure the stub.
+
+        Parameters
+        ----------
+        raise_on_get_states : bool, optional
+            When ``True``, every `get_states` call raises `HAClientError`.
+        states : list or None, optional
+            States returned by `get_states` (when not raising).
+        """
         self._raise = raise_on_get_states
         self._states = states or []
         self.calls = 0
 
     async def get_states(self) -> list[dict[str, Any]]:
+        """Return the configured states or raise as configured."""
         self.calls += 1
         if self._raise:
             raise HAClientError("boom")
         return list(self._states)
 
     async def get_state(self, entity_id: str) -> dict[str, Any] | None:
+        """Stub: return ``None`` for every entity."""
         return None
 
     async def call_service(
         self, domain: str, service: str, data: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
+        """Stub: return an empty state list."""
         return []
 
-    async def close(self) -> None: ...
+    async def close(self) -> None:
+        """Stub: no resources to release."""
 
 
 class _WS:
+    """`WebSocketPort` stub that captures the registered event handlers."""
+
     connected = True
 
     def __init__(self) -> None:
+        """Initialise the per-event-type handler map."""
         self.handlers: dict[str, Any] = {}
 
-    async def connect(self) -> None: ...
+    async def connect(self) -> None:
+        """Stub: no-op connect."""
 
-    async def close(self) -> None: ...
+    async def close(self) -> None:
+        """Stub: no-op close."""
 
     async def send_command(self, payload: dict[str, Any], *, timeout: float | None = None) -> Any:
+        """Stub: ignore commands and return ``None``."""
         return None
 
     async def subscribe_events(self, handler: Any, event_type: str | None = None) -> int:
+        """Record the handler keyed by *event_type* and return id ``1``."""
         if event_type is not None:
             self.handlers[event_type] = handler
         return 1
 
-    async def unsubscribe(self, subscription_id: int) -> None: ...
+    async def unsubscribe(self, subscription_id: int) -> None:
+        """Stub: no-op unsubscribe."""
 
     def on_disconnect(self, handler: Any) -> Any:
+        """Stub: return *handler* unchanged."""
         return handler
 
     def on_reconnect(self, handler: Any) -> Any:
+        """Stub: return *handler* unchanged."""
         return handler
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -15,12 +15,35 @@ from .fake_ha import FakeHA
 
 @pytest_asyncio.fixture
 async def running_fake_ha() -> FakeHA:
-    """A fake HA started by pytest-asyncio; used from a background thread."""
+    """Placeholder for an unused fixture.
+
+    Kept so that legacy ``running_fake_ha`` references in this file fail
+    loudly with a clear error rather than silently using a stale server.
+    Tests should depend on the standard ``fake_ha`` fixture from
+    `tests.conftest` instead.
+
+    Raises
+    ------
+    RuntimeError
+        Always — this fixture must not be used.
+    """
     raise RuntimeError("Use fake_ha fixture instead")
 
 
 def _run_sync_in_thread(fake_ha: FakeHA) -> dict[str, object]:
-    """Exercise SyncHAClient in a plain thread (no asyncio loop)."""
+    """Exercise `SyncHAClient` in a plain thread (no asyncio loop).
+
+    Parameters
+    ----------
+    fake_ha : FakeHA
+        Active fake server reachable from the thread.
+
+    Returns
+    -------
+    dict
+        Captured artefacts from the run; currently a single ``"calls"``
+        key with the recorded WS service-call payloads.
+    """
     results: dict[str, object] = {}
 
     def run() -> None:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -21,6 +21,25 @@ from .fake_ha import FakeHA
 
 
 async def _make_ws(fake_ha: FakeHA, **kwargs: Any) -> WebSocketClient:
+    """Build a connected `AiohttpWebSocketAdapter` against the fake server.
+
+    Used throughout the WebSocket tests as a one-line factory. Disables
+    keepalive pings and shortens the request timeout so failures surface
+    quickly.
+
+    Parameters
+    ----------
+    fake_ha : FakeHA
+        Active fake server providing `ws_url` / `token`.
+    **kwargs : Any
+        Additional keyword arguments forwarded to the adapter
+        constructor (e.g. ``reconnect=True``).
+
+    Returns
+    -------
+    WebSocketClient
+        Connected adapter ready to send commands.
+    """
     ws = WebSocketClient(
         fake_ha.ws_url,
         fake_ha.token,
@@ -180,17 +199,27 @@ async def test_disconnect_listener_sync(fake_ha: FakeHA) -> None:
 
 
 def threading_like_flag() -> _Flag:
+    """Return a fresh `_Flag` mimicking the public `threading.Event` shape.
+
+    Used by tests that need a sync-friendly signal without paying for
+    the real `threading.Event` machinery.
+    """
     return _Flag()
 
 
 class _Flag:
+    """Tiny ``threading.Event``-like flag used by sync-listener tests."""
+
     def __init__(self) -> None:
+        """Initialise the flag in the unset state."""
         self._set = False
 
     def set(self) -> None:
+        """Mark the flag as set."""
         self._set = True
 
     def is_set(self) -> bool:
+        """Return ``True`` when `set` has been called."""
         return self._set
 
 


### PR DESCRIPTION
## Summary

Closes the second batch of documentation gaps from the AGENTS.md audit. AGENTS.md requires NumPy-style docstrings for *complex test fixtures or utilities*; this PR documents the bits that are reused across modules.

## Changes

- **`tests/fake_ha.py`** — `FakeHA` class gains an `Attributes` section and every method (including the complex `_handle_ws` and `_dispatch` routers) is documented.
- **`tests/conftest.py`** — `fake_ha`, `client`, and `anyio_backend` fixtures get full `Yields`/`Parameters`/`Returns` sections.
- Reusable helper classes — `_FakeWS` (events, services, state_store), `_FakeRest`, `_Rest`, `_WS`, `_Custom`, `_Flag` — get class + method docstrings.
- Reusable helper functions — `_make_ws`, `_run_sync_in_thread`, `_find_call`, `threading_like_flag`, the `_make_*` browse-tree builders, `_browse_handler`, `_sonos_browse_handler` — get NumPy-style docstrings.

Per-test-function docstrings remain optional; this PR does not touch them.

## Verification

- `pytest tests/ --cov=haclient --cov-fail-under=95` — 248 passed, 96.45% coverage.
- `ruff check src tests` — clean.
- `ruff format --check src tests` — clean.
- `mypy src` — clean.