### PR TITLE
Document private helpers and dunders in source

### DIFF
--- a/src/haclient/api.py
+++ b/src/haclient/api.py
@@ -217,13 +217,41 @@ class HAClient:
         )
 
     def _select_active_domains(self, requested: list[str] | None) -> list[DomainSpec[Any]]:
-        """Return the specs that should be active for this client."""
+        """Return the specs that should be active for this client.
+
+        Parameters
+        ----------
+        requested : list of str or None
+            Restrict to these domain names, or ``None`` to load every
+            registered domain.
+
+        Returns
+        -------
+        list of DomainSpec
+            Specs in registration order.
+        """
         if requested is None:
             return list(self._registry)
         return self._registry.filter(requested)
 
     def _make_event_router(self, spec: DomainSpec[Any]) -> Callable[[dict[str, Any]], None]:
-        """Build a router that forwards a domain's HA events to its handler."""
+        """Build a router that forwards a domain's HA events to its handler.
+
+        The returned closure looks up the entity by id, then delegates
+        to *spec*'s ``on_event`` callback. Events without a known entity
+        or with no registered handler are silently dropped.
+
+        Parameters
+        ----------
+        spec : DomainSpec
+            The spec whose ``on_event`` callback should receive routed
+            events.
+
+        Returns
+        -------
+        callable
+            Synchronous event handler suitable for `EventBus.subscribe`.
+        """
 
         on_event = spec.on_event
 
@@ -245,6 +273,7 @@ class HAClient:
     # -- Lifecycle ----------------------------------------------------
 
     async def __aenter__(self) -> HAClient:
+        """Enter the async context manager by calling `connect`."""
         await self.connect()
         return self
 
@@ -254,6 +283,7 @@ class HAClient:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
+        """Exit the async context manager by calling `close`."""
         await self.close()
 
     async def connect(self) -> None:

--- a/src/haclient/config.py
+++ b/src/haclient/config.py
@@ -138,5 +138,13 @@ class SharedSession:
     """
 
     def __init__(self, session: aiohttp.ClientSession | None = None) -> None:
+        """Wrap *session* and record whether it was externally owned.
+
+        Parameters
+        ----------
+        session : aiohttp.ClientSession or None, optional
+            Pre-existing session to share between transports. ``None``
+            leaves each adapter to manage its own session.
+        """
         self.session = session
         self.shared = session is not None

--- a/src/haclient/core/events.py
+++ b/src/haclient/core/events.py
@@ -149,6 +149,12 @@ class EventBus:
 
         Used by `StateStore` while the initial REST snapshot is being
         applied. Idempotent.
+
+        Parameters
+        ----------
+        event_type : str
+            Event type whose incoming frames should be queued in memory
+            until `drain_buffer` (or `discard_buffer`) is called.
         """
         self._buffers.setdefault(event_type, deque())
 

--- a/src/haclient/domains/media_player.py
+++ b/src/haclient/domains/media_player.py
@@ -33,7 +33,25 @@ def _now_playing_from_attrs(
     attrs: dict[str, Any],
     base_url: str | None = None,
 ) -> NowPlaying:
-    """Build a `NowPlaying` from a raw HA attributes dict."""
+    """Build a `NowPlaying` from a raw HA attributes dict.
+
+    The HA ``entity_picture`` attribute is a path relative to the HA
+    base URL; this helper resolves it against *base_url* when provided
+    so consumers receive an absolute URL.
+
+    Parameters
+    ----------
+    attrs : dict
+        The entity's ``attributes`` dictionary.
+    base_url : str or None, optional
+        Base URL used to absolutise ``entity_picture``. ``None`` leaves
+        the value untouched.
+
+    Returns
+    -------
+    NowPlaying
+        Frozen snapshot of the playing media.
+    """
     features = attrs.get("supported_features") or 0
     picture = attrs.get("entity_picture")
     if isinstance(picture, str) and base_url and picture.startswith("/"):
@@ -200,6 +218,19 @@ class MediaPlayer(Entity):
         store: StateStore,
         clock: Clock,
     ) -> None:
+        """Initialise the media player and its media-change listener list.
+
+        Parameters
+        ----------
+        entity_id : str
+            Fully-qualified entity id (e.g. ``"media_player.kitchen"``).
+        services : ServiceCaller
+            Service-call port used to invoke HA services.
+        store : StateStore
+            State store the entity registers itself with.
+        clock : Clock
+            Scheduler used to dispatch async listeners.
+        """
         super().__init__(entity_id, services, store, clock)
         self._media_change_listeners: list[ValueChangeHandler] = []
 
@@ -421,6 +452,13 @@ class MediaPlayer(Entity):
         node_count = 0
 
         async def walk(node: dict[str, Any], depth: int, category: str | None) -> None:
+            """Recurse through *node*'s children, collecting playable items.
+
+            Updates *collected*, *seen*, and *node_count* from the
+            enclosing scope. Honours the *max_depth* and *max_nodes*
+            bounds and silently skips children that are missing
+            playback identifiers.
+            """
             nonlocal node_count
             if node_count >= max_nodes:
                 return

--- a/src/haclient/domains/timer.py
+++ b/src/haclient/domains/timer.py
@@ -64,6 +64,22 @@ class Timer(Entity):
         store: StateStore,
         clock: Clock,
     ) -> None:
+        """Initialise the timer and its event-driven listener lists.
+
+        Beyond the base `Entity` setup, this also primes the persistence
+        flags used by the auto-cleanup logic in `_handle_state_changed`.
+
+        Parameters
+        ----------
+        entity_id : str
+            Fully-qualified entity id (e.g. ``"timer.cooldown"``).
+        services : ServiceCaller
+            Service-call port used to invoke HA services.
+        store : StateStore
+            State store the entity registers itself with.
+        clock : Clock
+            Scheduler used to dispatch async listeners.
+        """
         super().__init__(entity_id, services, store, clock)
         self._finished_listeners: list[ValueChangeHandler] = []
         self._cancelled_listeners: list[ValueChangeHandler] = []

--- a/src/haclient/infra/ws_aiohttp.py
+++ b/src/haclient/infra/ws_aiohttp.py
@@ -140,7 +140,21 @@ class AiohttpWebSocketAdapter:
         self._connected.set()
 
     async def close(self) -> None:
-        """Close the WebSocket and stop background tasks."""
+        """Close the WebSocket and stop background tasks.
+
+        Notes
+        -----
+        Side-effects, in order:
+
+        1. Marks the adapter as closing so the reader/keepalive loops
+           exit instead of triggering a reconnect.
+        2. Cancels and awaits the keepalive task.
+        3. Closes the underlying socket and waits up to 5 seconds for
+           the reader task to drain.
+        4. Fails any pending command/pong futures with
+           `ConnectionClosedError`.
+        5. Closes the owned aiohttp session, if any.
+        """
         self._closing = True
         self._connected.clear()
         if self._keepalive_task is not None:

--- a/src/haclient/sync.py
+++ b/src/haclient/sync.py
@@ -35,6 +35,12 @@ class _LoopThread:
     """Run an asyncio event loop in a dedicated thread."""
 
     def __init__(self) -> None:
+        """Start the background loop and block until it is running.
+
+        Spawns a daemon thread that owns a fresh event loop and waits
+        on a `threading.Event` until the loop has signalled that it is
+        ready to accept work.
+        """
         self.loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._run, name="haclient-sync-loop", daemon=True)
         self._started = threading.Event()
@@ -97,6 +103,13 @@ class _SyncProxy:
         object.__setattr__(self, "_loop_thread", loop_thread)
 
     def __getattr__(self, name: str) -> Any:
+        """Forward attribute access, blocking-wrapping coroutine functions.
+
+        When the wrapped target's attribute is a coroutine function, a
+        sync wrapper is returned that submits the coroutine to the
+        background loop and waits for the result. Non-coroutine
+        attributes are passed through unchanged.
+        """
         attr = getattr(self._target, name)
         if inspect.iscoroutinefunction(attr):
             loop_thread = self._loop_thread
@@ -110,9 +123,11 @@ class _SyncProxy:
         return attr
 
     def __setattr__(self, name: str, value: Any) -> None:
+        """Forward attribute writes to the wrapped target."""
         setattr(self._target, name, value)
 
     def __repr__(self) -> str:
+        """Return a debug representation that highlights the wrapper."""
         return f"<Sync {self._target!r}>"
 
 
@@ -128,12 +143,21 @@ class _SyncDomainAccessor:
         object.__setattr__(self, "_loop_thread", loop_thread)
 
     def __call__(self, name: str) -> Any:
+        """Look up an entity by *name* and return a sync proxy."""
         return _SyncProxy(self._accessor(name), self._loop_thread)
 
     def __getitem__(self, name: str) -> Any:
+        """Look up an entity by *name* using ``[]`` syntax."""
         return _SyncProxy(self._accessor[name], self._loop_thread)
 
     def __getattr__(self, name: str) -> Any:
+        """Forward attribute access, blocking-wrapping coroutine functions.
+
+        Mirrors `_SyncProxy.__getattr__` but additionally wraps any
+        returned object that exposes ``entity_id`` in a `_SyncProxy`,
+        so that domain-level operations (e.g. ``ha.scene.create(...)``)
+        return blocking entities just like direct lookups do.
+        """
         attr = getattr(self._accessor, name)
         if inspect.iscoroutinefunction(attr):
             loop_thread = self._loop_thread
@@ -217,10 +241,12 @@ class SyncHAClient:
             self._loop_thread.stop()
 
     def __enter__(self) -> SyncHAClient:
+        """Enter the sync context manager by calling `connect`."""
         self.connect()
         return self
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        """Exit the sync context manager by calling `close`."""
         self.close()
 
     def refresh_all(self) -> None:


### PR DESCRIPTION
## Summary

Closes the final batch of documentation gaps from the AGENTS.md audit. These are MINOR items: non-obvious private helpers and context-manager dunders that are not public API but warrant docstrings because their behaviour is non-trivial.

## Changes

- `HAClient.__aenter__` / `__aexit__` — explicit one-line docstrings.
- `HAClient._select_active_domains` and `_make_event_router` — Parameters / Returns.
- `SyncHAClient.__enter__` / `__exit__` — explicit one-line docstrings.
- `_LoopThread.__init__`, `_SyncProxy.__getattr__` / `__setattr__` / `__repr__`, `_SyncDomainAccessor.__call__` / `__getitem__` / `__getattr__` — describe the wrapping behaviour.
- `SharedSession.__init__` — Parameters section.
- `EventBus.enable_buffering` — Parameters section.
- `_now_playing_from_attrs` — Parameters / Returns.
- `MediaPlayer.__init__` and `Timer.__init__` — Parameters sections.
- Inner `walk` helper inside `MediaPlayer.favorites` — describes the closure's contract.
- `AiohttpWebSocketAdapter.close` — Notes section enumerating side-effects.

No behavior changes — purely docstring additions.

## Verification

- `pytest tests/ --cov=haclient --cov-fail-under=95` — 248 passed, 96.45% coverage.
- `ruff check src tests` — clean.
- `ruff format --check src tests` — clean.
- `mypy src` — clean.
