### PR TITLE
Remove hardcoded domain accessors from façade

### DIFF
--- a/src/haclient/__init__.py
+++ b/src/haclient/__init__.py
@@ -26,19 +26,6 @@ from haclient.core.plugins import (
 from haclient.core.registry import EntityRegistry
 from haclient.core.services import ServiceCaller
 from haclient.core.state import StateStore
-from haclient.domains import (
-    BinarySensor,
-    Climate,
-    Cover,
-    FavoriteItem,
-    Light,
-    MediaPlayer,
-    NowPlaying,
-    Scene,
-    Sensor,
-    Switch,
-    Timer,
-)
 from haclient.entity.base import Entity
 from haclient.exceptions import (
     AuthenticationError,
@@ -53,14 +40,11 @@ from haclient.sync import SyncHAClient
 
 __all__ = [
     "AuthenticationError",
-    "BinarySensor",
-    "Climate",
     "Clock",
     "CommandError",
     "Connection",
     "ConnectionClosedError",
     "ConnectionConfig",
-    "Cover",
     "DomainAccessor",
     "DomainRegistry",
     "DomainSpec",
@@ -69,22 +53,14 @@ __all__ = [
     "EntityNotFoundError",
     "EntityRegistry",
     "EventBus",
-    "FavoriteItem",
     "HAClient",
     "HAClientError",
-    "Light",
-    "MediaPlayer",
-    "NowPlaying",
     "RestPort",
-    "Scene",
-    "Sensor",
     "ServiceCaller",
     "ServicePolicy",
     "StateStore",
-    "Switch",
     "SyncHAClient",
     "TimeoutError",
-    "Timer",
     "WebSocketPort",
     "register_domain",
 ]

--- a/src/haclient/api.py
+++ b/src/haclient/api.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 
 import aiohttp
 
@@ -56,17 +56,6 @@ from haclient.core.state import StateStore
 from haclient.infra.rest_aiohttp import AiohttpRestAdapter
 from haclient.infra.ws_aiohttp import AiohttpWebSocketAdapter
 from haclient.ports import RestPort, WebSocketPort
-
-if TYPE_CHECKING:
-    from haclient.domains.binary_sensor import BinarySensor
-    from haclient.domains.climate import Climate
-    from haclient.domains.cover import Cover
-    from haclient.domains.light import Light
-    from haclient.domains.media_player import MediaPlayer
-    from haclient.domains.scene import Scene
-    from haclient.domains.sensor import Sensor
-    from haclient.domains.switch import Switch
-    from haclient.domains.timer import Timer
 
 
 class HAClient:
@@ -406,126 +395,37 @@ class HAClient:
             raise KeyError(f"Domain {name!r} is not active on this client")
         return accessor
 
-    # -- Built-in typed accessors ------------------------------------
+    def __getattr__(self, name: str) -> DomainAccessor[Any]:
+        """Return the `DomainAccessor` for a registered domain.
 
-    def light(self, name: str) -> Light:
-        """Return the `Light` for *name*.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name (without the ``light.`` prefix) or full
-            ``light.<name>`` entity id.
-
-        Returns
-        -------
-        Light
-            The (cached) entity instance.
-        """
-        return cast("Light", self._accessors["light"][name])
-
-    def switch(self, name: str) -> Switch:
-        """Return the `Switch` for *name*.
+        Enables ``ha.light("kitchen")``, ``ha.scene.create(...)``, etc.
+        for *any* registered domain — built-in or third-party — without
+        the façade needing to know which domains exist.
 
         Parameters
         ----------
         name : str
-            Short entity name (without the ``switch.`` prefix) or full
-            ``switch.<name>`` entity id.
+            The domain or accessor name (e.g. ``"light"``,
+            ``"media_player"``).
 
         Returns
         -------
-        Switch
-            The (cached) entity instance.
+        DomainAccessor
+            The accessor for the domain.
+
+        Raises
+        ------
+        AttributeError
+            If *name* does not match any active domain.
         """
-        return cast("Switch", self._accessors["switch"][name])
-
-    def climate(self, name: str) -> Climate:
-        """Return the `Climate` for *name*.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name (without the ``climate.`` prefix) or full
-            ``climate.<name>`` entity id.
-
-        Returns
-        -------
-        Climate
-            The (cached) entity instance.
-        """
-        return cast("Climate", self._accessors["climate"][name])
-
-    def cover(self, name: str) -> Cover:
-        """Return the `Cover` for *name*.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name (without the ``cover.`` prefix) or full
-            ``cover.<name>`` entity id.
-
-        Returns
-        -------
-        Cover
-            The (cached) entity instance.
-        """
-        return cast("Cover", self._accessors["cover"][name])
-
-    def sensor(self, name: str) -> Sensor:
-        """Return the `Sensor` for *name*.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name (without the ``sensor.`` prefix) or full
-            ``sensor.<name>`` entity id.
-
-        Returns
-        -------
-        Sensor
-            The (cached) entity instance.
-        """
-        return cast("Sensor", self._accessors["sensor"][name])
-
-    def binary_sensor(self, name: str) -> BinarySensor:
-        """Return the `BinarySensor` for *name*.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name (without the ``binary_sensor.`` prefix) or
-            full ``binary_sensor.<name>`` entity id.
-
-        Returns
-        -------
-        BinarySensor
-            The (cached) entity instance.
-        """
-        return cast("BinarySensor", self._accessors["binary_sensor"][name])
-
-    def media_player(self, name: str) -> MediaPlayer:
-        """Return the `MediaPlayer` for *name*.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name (without the ``media_player.`` prefix) or
-            full ``media_player.<name>`` entity id.
-
-        Returns
-        -------
-        MediaPlayer
-            The (cached) entity instance.
-        """
-        return cast("MediaPlayer", self._accessors["media_player"][name])
-
-    @property
-    def scene(self) -> DomainAccessor[Scene]:
-        """Return the scene accessor (supports lookup + ``create``/``apply``)."""
-        return cast("DomainAccessor[Scene]", self._accessors["scene"])
-
-    @property
-    def timer(self) -> DomainAccessor[Timer]:
-        """Return the timer accessor (supports lookup + ``create``)."""
-        return cast("DomainAccessor[Timer]", self._accessors["timer"])
+        # Guard: only intercept after __init__ has populated _accessors.
+        try:
+            accessors: dict[str, DomainAccessor[Any]] = self.__dict__["_accessors"]
+        except KeyError:
+            raise AttributeError(name) from None
+        try:
+            return accessors[name]
+        except KeyError:
+            raise AttributeError(
+                f"{type(self).__name__!r} object has no attribute {name!r}"
+            ) from None

--- a/src/haclient/sync.py
+++ b/src/haclient/sync.py
@@ -339,117 +339,29 @@ class SyncHAClient:
         """
         return _SyncDomainAccessor(self._client.domain(name), self._loop_thread)
 
-    def media_player(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `MediaPlayer`.
+    def __getattr__(self, name: str) -> _SyncDomainAccessor:
+        """Return a sync domain accessor for any registered domain.
+
+        Enables ``ha.light("kitchen")``, ``ha.scene.create(...)``, etc.
+        identically to `HAClient.__getattr__`, but wrapping everything
+        in blocking proxies.
 
         Parameters
         ----------
         name : str
-            Short entity name or full ``media_player.<name>`` id.
+            The domain or accessor name.
 
         Returns
         -------
-        _SyncProxy
-            Blocking proxy delegating to the async `MediaPlayer`.
+        _SyncDomainAccessor
+            Blocking accessor wrapping the underlying async accessor.
+
+        Raises
+        ------
+        AttributeError
+            If *name* does not match any active domain.
         """
-        return _SyncProxy(self._client.media_player(name), self._loop_thread)
-
-    def light(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Light`.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name or full ``light.<name>`` id.
-
-        Returns
-        -------
-        _SyncProxy
-            Blocking proxy delegating to the async `Light`.
-        """
-        return _SyncProxy(self._client.light(name), self._loop_thread)
-
-    def switch(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Switch`.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name or full ``switch.<name>`` id.
-
-        Returns
-        -------
-        _SyncProxy
-            Blocking proxy delegating to the async `Switch`.
-        """
-        return _SyncProxy(self._client.switch(name), self._loop_thread)
-
-    def climate(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Climate`.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name or full ``climate.<name>`` id.
-
-        Returns
-        -------
-        _SyncProxy
-            Blocking proxy delegating to the async `Climate`.
-        """
-        return _SyncProxy(self._client.climate(name), self._loop_thread)
-
-    def cover(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Cover`.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name or full ``cover.<name>`` id.
-
-        Returns
-        -------
-        _SyncProxy
-            Blocking proxy delegating to the async `Cover`.
-        """
-        return _SyncProxy(self._client.cover(name), self._loop_thread)
-
-    def sensor(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `Sensor`.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name or full ``sensor.<name>`` id.
-
-        Returns
-        -------
-        _SyncProxy
-            Blocking proxy delegating to the async `Sensor`.
-        """
-        return _SyncProxy(self._client.sensor(name), self._loop_thread)
-
-    def binary_sensor(self, name: str) -> Any:
-        """Return a sync proxy wrapping the async `BinarySensor`.
-
-        Parameters
-        ----------
-        name : str
-            Short entity name or full ``binary_sensor.<name>`` id.
-
-        Returns
-        -------
-        _SyncProxy
-            Blocking proxy delegating to the async `BinarySensor`.
-        """
-        return _SyncProxy(self._client.binary_sensor(name), self._loop_thread)
-
-    @property
-    def scene(self) -> _SyncDomainAccessor:
-        """Return a sync scene accessor."""
-        return _SyncDomainAccessor(self._client.scene, self._loop_thread)
-
-    @property
-    def timer(self) -> _SyncDomainAccessor:
-        """Return a sync timer accessor."""
-        return _SyncDomainAccessor(self._client.timer, self._loop_thread)
+        # Delegate to HAClient.__getattr__ which returns a DomainAccessor
+        # or raises AttributeError.
+        accessor = getattr(self._client, name)
+        return _SyncDomainAccessor(accessor, self._loop_thread)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,8 +7,10 @@ from typing import Any
 
 import pytest
 
-from haclient import HAClient, Light, Switch
+from haclient import HAClient
 from haclient.config import derive_ws_url
+from haclient.domains.light import Light
+from haclient.domains.switch import Switch
 from haclient.exceptions import ConnectionClosedError, HAClientError
 
 from .fake_ha import FakeHA

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from haclient import EntityRegistry, HAClient, Light
+from haclient import EntityRegistry, HAClient
+from haclient.domains.light import Light
 from haclient.exceptions import EntityNotFoundError
 
 


### PR DESCRIPTION
## Summary

- Replace 9 hardcoded typed domain methods/properties on `HAClient` and `SyncHAClient` with a single `__getattr__` that dynamically delegates to the accessor dict
- Remove domain entity class re-exports (`Light`, `Switch`, etc.) from `haclient/__init__.py`
- Update 2 test files to import domain classes from `haclient.domains.*` instead

## Why

The hexagonal architecture plan states the façade should be domain-agnostic — "adding a new domain is purely a matter of registering a DomainSpec." But `api.py`, `sync.py`, and `__init__.py` all hardcoded references to 9 specific domains, contradicting the documented architecture.

## What changes

| File | Before | After |
|------|--------|-------|
| `api.py` | 9 typed methods + 9 TYPE_CHECKING imports | `__getattr__` → `self._accessors[name]` |
| `sync.py` | 9 mirrored methods/properties | `__getattr__` → `_SyncDomainAccessor(getattr(self._client, name))` |
| `__init__.py` | Explicit imports of `Light`, `Switch`, etc. | Removed — import from `haclient.domains.light` etc. |

## Behavior

`ha.light("kitchen")` works identically — `__getattr__("light")` returns the `DomainAccessor`, then `__call__("kitchen")` returns the entity. Same for all domains including `ha.scene.create(...)` and `ha.timer.create(...)`.

## Verification

- 248 tests pass, 96.22% coverage (threshold: 95%)
- ruff clean, mypy strict clean