### PR TITLE
docs: update README to reflect library redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,20 @@
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-brightgreen?logo=dependabot)](https://github.com/graphras-com/HaClient/network/updates)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-Async-first, high-level Python client for Home Assistant with REST and WebSocket support. Provides typed domain accessors, real-time state tracking, and a synchronous wrapper for scripts and REPL use.
+Async-first, high-level Python client for Home Assistant with REST and WebSocket support. Provides typed domain accessors, real-time state tracking, automatic reconnection, and a synchronous wrapper for scripts and REPL use.
+
+**[Documentation](https://graphras-com.github.io/HaClient/)**
 
 ## Features
 
 - Async context manager with automatic WebSocket connection and state priming
-- Typed domain accessors: light, switch, climate, cover, sensor, binary sensor, media player
+- Typed domain accessors: light, switch, climate, cover, sensor, binary sensor, media player, scene, timer
+- Intent-specific methods over raw service calls (e.g. `light.set_brightness(200)` instead of `light.turn_on(brightness=200)`)
 - Real-time state change listeners with granular attribute and state-transition filtering
 - Synchronous blocking wrapper for scripts, REPL, and Jupyter
 - Automatic WebSocket reconnection with exponential backoff
+- Configurable service routing policy (`ws`, `rest`, or `auto`)
+- Plugin system for third-party domain extensions via entry points
 - Fully typed (PEP 561) with strict mypy enforcement
 - Single runtime dependency (`aiohttp`)
 
@@ -45,12 +50,17 @@ pip install .
 ```python
 from haclient import HAClient
 
-async with HAClient("http://localhost:8123", token="YOUR_TOKEN") as ha:
+async with HAClient.from_url("http://localhost:8123", token="YOUR_TOKEN") as ha:
     light = ha.light("kitchen")
-    await light.turn_on(brightness=200)
+    await light.set_brightness(200)
+    await light.set_kelvin(3000)
 
     switch = ha.switch("garage_door")
-    await switch.turn_off()
+    await switch.off()
+
+    # Listen for state changes
+    sensor = ha.sensor("outdoor_temperature")
+    sensor.on_value_change(lambda old, new: print(f"Temp: {old} -> {new}"))
 ```
 
 ### Synchronous
@@ -58,17 +68,25 @@ async with HAClient("http://localhost:8123", token="YOUR_TOKEN") as ha:
 ```python
 from haclient import SyncHAClient
 
-with SyncHAClient("http://localhost:8123", token="YOUR_TOKEN") as ha:
+with SyncHAClient.from_url("http://localhost:8123", token="YOUR_TOKEN") as ha:
     light = ha.light("kitchen")
-    light.turn_on(brightness=200)
+    light.set_brightness(200)
+
+    player = ha.media_player("living_room")
+    player.set_volume(0.5)
 ```
 
 ## Configuration
 
-The client requires two parameters:
+Create a client with `HAClient.from_url()` or by passing a `ConnectionConfig` directly:
 
-- **`url`** -- Base URL of your Home Assistant instance (e.g., `http://localhost:8123`)
-- **`token`** -- Long-lived access token generated from Home Assistant UI
+- **`base_url`** -- Base URL of your Home Assistant instance (e.g. `http://localhost:8123`)
+- **`token`** -- Long-lived access token generated from the Home Assistant UI
+- **`reconnect`** -- Enable automatic WebSocket reconnection (default: `True`)
+- **`ping_interval`** -- WebSocket keepalive interval in seconds (default: `30`)
+- **`request_timeout`** -- Timeout for REST and WS commands in seconds (default: `10`)
+- **`verify_ssl`** -- Verify SSL certificates (default: `True`)
+- **`service_policy`** -- Service call routing: `"ws"`, `"rest"`, or `"auto"` (default: `"auto"`)
 
 Store tokens securely using environment variables or a secrets manager. Do not commit tokens to version control.
 
@@ -117,7 +135,7 @@ GitHub Actions workflows handle:
 
 - **Lint** -- Ruff check and format verification
 - **Type Check** -- Strict mypy analysis
-- **Tests** -- Pytest matrix across Python 3.11/3.12 with 95% coverage threshold
+- **Tests** -- Pytest matrix across Python 3.11/3.12/3.13 with 95% coverage threshold
 - **Secrets Scan** -- Gitleaks full-history scan
 - **Release** -- Automated GitHub release on `v*` tags
 - **Dependabot** -- Weekly dependency updates for pip and GitHub Actions


### PR DESCRIPTION
## Summary

- Updated code examples to use the current API (`HAClient.from_url()`, `set_brightness()`, `off()`, etc.)
- Added missing domains (scene, timer) to the feature list
- Added documentation link to https://graphras-com.github.io/HaClient/
- Updated configuration section with all current `ConnectionConfig` options
- Fixed CI/CD section to include Python 3.13
- Added notes on service policy, plugin system, and intent-specific methods