### PR TITLE
feat(domains): add Lock domain (#32)

### DIFF
--- a/src/haclient/domains/__init__.py
+++ b/src/haclient/domains/__init__.py
@@ -9,6 +9,7 @@ from haclient.domains.binary_sensor import BinarySensor
 from haclient.domains.climate import Climate
 from haclient.domains.cover import Cover
 from haclient.domains.light import Light
+from haclient.domains.lock import Lock
 from haclient.domains.media_player import FavoriteItem, MediaPlayer, NowPlaying
 from haclient.domains.scene import Scene
 from haclient.domains.sensor import Sensor
@@ -21,6 +22,7 @@ __all__ = [
     "Cover",
     "FavoriteItem",
     "Light",
+    "Lock",
     "MediaPlayer",
     "NowPlaying",
     "Scene",

--- a/src/haclient/domains/lock.py
+++ b/src/haclient/domains/lock.py
@@ -1,0 +1,159 @@
+"""``lock`` domain implementation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from haclient.core.plugins import DomainSpec, register_domain
+from haclient.entity.base import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+# Home Assistant ``LockEntityFeature`` bitmask.
+# See homeassistant/components/lock/const.py.
+_FEATURE_OPEN = 1
+
+
+class Lock(Entity):
+    """A Home Assistant lock entity.
+
+    Provides intent-specific actions (``lock``, ``unlock``, ``open``)
+    and state introspection (``is_locked``, ``is_unlocked``,
+    ``is_locking``, ``is_unlocking``, ``is_jammed``) rather than
+    exposing raw ``lock.lock`` / ``lock.unlock`` service calls.
+
+    The ``open`` action is only available on lock hardware that
+    advertises the ``OPEN`` (unlatch) feature via the
+    ``supported_features`` attribute; on locks without it ``open`` is a
+    no-op that logs a debug message, so user code does not break across
+    heterogeneous lock backends. Callers can pre-check with
+    `supports_open`.
+    """
+
+    domain = "lock"
+
+    # -- Listener decorators ------------------------------------------
+
+    def on_lock(self, func: Any) -> Any:
+        """Register a listener for when the lock becomes locked.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``locked`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_state_transition_listener("locked", func)
+
+    def on_unlock(self, func: Any) -> Any:
+        """Register a listener for when the lock becomes unlocked.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``unlocked`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_state_transition_listener("unlocked", func)
+
+    def on_jam(self, func: Any) -> Any:
+        """Register a listener for when the lock jams.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``jammed`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_state_transition_listener("jammed", func)
+
+    # -- State properties ---------------------------------------------
+
+    @property
+    def is_locked(self) -> bool:
+        """Whether the lock is currently locked."""
+        return self.state == "locked"
+
+    @property
+    def is_unlocked(self) -> bool:
+        """Whether the lock is currently unlocked."""
+        return self.state == "unlocked"
+
+    @property
+    def is_locking(self) -> bool:
+        """Whether the lock is currently in the process of locking."""
+        return self.state == "locking"
+
+    @property
+    def is_unlocking(self) -> bool:
+        """Whether the lock is currently in the process of unlocking."""
+        return self.state == "unlocking"
+
+    @property
+    def is_jammed(self) -> bool:
+        """Whether the lock is currently jammed."""
+        return self.state == "jammed"
+
+    @property
+    def supports_open(self) -> bool:
+        """Whether the underlying lock hardware supports the ``open`` action.
+
+        Returns
+        -------
+        bool
+            ``True`` if the entity advertises the ``OPEN`` feature in
+            its ``supported_features`` bitmask, otherwise ``False``.
+        """
+        features = self.attributes.get("supported_features")
+        if not isinstance(features, int):
+            return False
+        return bool(features & _FEATURE_OPEN)
+
+    # -- Actions ------------------------------------------------------
+
+    async def lock(self) -> None:
+        """Engage the lock."""
+        await self._call_service("lock")
+
+    async def unlock(self) -> None:
+        """Release the lock."""
+        await self._call_service("unlock")
+
+    async def open(self) -> None:
+        """Open (unlatch) the lock, if supported.
+
+        Degrades safely: if the lock does not advertise the ``OPEN``
+        feature, this method logs a debug message and returns without
+        raising, so user code that targets a heterogeneous fleet of
+        locks does not break on hardware that lacks an unlatch.
+
+        Callers that need to know whether the action will actually be
+        dispatched can check `supports_open` first.
+        """
+        if not self.supports_open:
+            _LOGGER.debug(
+                "open() unsupported for %s; skipping (no LockEntityFeature.OPEN)",
+                self.entity_id,
+            )
+            return
+        await self._call_service("open")
+
+
+SPEC: DomainSpec[Lock] = register_domain(DomainSpec(name="lock", entity_cls=Lock))
+"""The `DomainSpec` registered with the shared `DomainRegistry`."""

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -639,3 +639,112 @@ async def test_timer_time_remaining_bad_remaining() -> None:
         assert t.time_remaining is None
     finally:
         await ha.close()
+
+
+# ---------------------------------------------------------------------------
+# Lock
+# ---------------------------------------------------------------------------
+
+
+async def test_lock_actions_and_state(client: HAClient, fake_ha: FakeHA) -> None:
+    """``lock`` / ``unlock`` dispatch the expected services and state flags work."""
+    door = client.lock("front_door")
+    await door.lock()
+    await door.unlock()
+    svc = [c["service"] for c in fake_ha.ws_service_calls]
+    assert svc == ["lock", "unlock"]
+    assert all(c["domain"] == "lock" for c in fake_ha.ws_service_calls)
+    assert all(
+        c["service_data"]["entity_id"] == "lock.front_door" for c in fake_ha.ws_service_calls
+    )
+
+    door._apply_state({"state": "locked", "attributes": {}})
+    assert door.is_locked
+    assert not door.is_unlocked
+    assert not door.is_jammed
+
+    door._apply_state({"state": "unlocked", "attributes": {}})
+    assert door.is_unlocked
+    assert not door.is_locked
+
+    door._apply_state({"state": "locking", "attributes": {}})
+    assert door.is_locking
+
+    door._apply_state({"state": "unlocking", "attributes": {}})
+    assert door.is_unlocking
+
+    door._apply_state({"state": "jammed", "attributes": {}})
+    assert door.is_jammed
+
+
+async def test_lock_open_supported(client: HAClient, fake_ha: FakeHA) -> None:
+    """``open()`` dispatches ``lock.open`` when ``OPEN`` feature is advertised."""
+    door = client.lock("smart_door")
+    # Bit 1 = LockEntityFeature.OPEN.
+    door._apply_state({"state": "locked", "attributes": {"supported_features": 1}})
+    assert door.supports_open is True
+
+    await door.open()
+    services = [c["service"] for c in fake_ha.ws_service_calls]
+    assert services == ["open"]
+
+
+async def test_lock_open_unsupported_is_noop(client: HAClient, fake_ha: FakeHA) -> None:
+    """``open()`` degrades safely when the hardware lacks the OPEN feature."""
+    door = client.lock("basic_door")
+    door._apply_state({"state": "locked", "attributes": {"supported_features": 0}})
+    assert door.supports_open is False
+
+    await door.open()
+    assert fake_ha.ws_service_calls == []
+
+    # Missing attribute entirely behaves the same.
+    door._apply_state({"state": "locked", "attributes": {}})
+    assert door.supports_open is False
+    await door.open()
+    assert fake_ha.ws_service_calls == []
+
+    # Non-int ``supported_features`` is treated as unsupported.
+    door._apply_state({"state": "locked", "attributes": {"supported_features": "1"}})
+    assert door.supports_open is False
+
+
+async def test_lock_listeners(client: HAClient, fake_ha: FakeHA) -> None:
+    """Lock listener decorators fire on the relevant state transitions."""
+    door = client.lock("hall")
+    locked: list[tuple[Any, Any]] = []
+    unlocked: list[tuple[Any, Any]] = []
+    jammed: list[tuple[Any, Any]] = []
+
+    @door.on_lock
+    def _on_lock(old: Any, new: Any) -> None:
+        locked.append((old, new))
+
+    @door.on_unlock
+    def _on_unlock(old: Any, new: Any) -> None:
+        unlocked.append((old, new))
+
+    @door.on_jam
+    def _on_jam(old: Any, new: Any) -> None:
+        jammed.append((old, new))
+
+    await fake_ha.push_state_changed(
+        "lock.hall",
+        {"state": "locked", "attributes": {}},
+        {"state": "unlocked", "attributes": {}},
+    )
+    await fake_ha.push_state_changed(
+        "lock.hall",
+        {"state": "unlocked", "attributes": {}},
+        {"state": "locked", "attributes": {}},
+    )
+    await fake_ha.push_state_changed(
+        "lock.hall",
+        {"state": "jammed", "attributes": {}},
+        {"state": "locked", "attributes": {}},
+    )
+    await asyncio.sleep(0.05)
+
+    assert locked == [("unlocked", "locked")]
+    assert unlocked == [("locked", "unlocked")]
+    assert jammed == [("locked", "jammed")]


### PR DESCRIPTION
## Issue assessment

Closes #32.

The request is valid and well-aligned with the project mission: locks are a core HA domain (alongside Light, Switch, Cover, Climate, Media Player) and the absence of a typed wrapper forced users into raw service calls with no state introspection or event hooks — exactly the kind of inconsistency `AGENTS.md` calls out as non-negotiable.

## Fix

New `src/haclient/domains/lock.py` modeled on the existing `switch` / `cover` patterns:

- **State:** `is_locked`, `is_unlocked`, `is_locking`, `is_unlocking`, `is_jammed`.
- **Actions:** `lock()`, `unlock()`, `open()`.
- **Listeners:** `on_lock`, `on_unlock`, `on_jam` (decorators returning the wrapped function, matching existing domains).
- **Graceful degradation:** `open()` checks the HA `LockEntityFeature.OPEN` (bit 1) on the entity's `supported_features` attribute. If absent it logs at debug and returns without dispatching, so user code targeting heterogeneous lock fleets does not break. `supports_open` is exposed for callers that want to gate the call explicitly.

Registered in `src/haclient/domains/__init__.py` so `ha.lock("front_door")` is auto-wired through the standard `DomainAccessor` machinery.

## Tests / checks

Added four tests in `tests/test_domains.py`:

- `test_lock_actions_and_state` — service dispatch + all state properties.
- `test_lock_open_supported` — `open()` fires when feature is advertised.
- `test_lock_open_unsupported_is_noop` — degrades safely (missing attr, zero bitmask, non-int).
- `test_lock_listeners` — `on_lock` / `on_unlock` / `on_jam` decorators fire on the right transitions.

Validation run:

- `ruff check src tests` — clean
- `ruff format --check src tests` — clean
- `mypy src` (strict) — no issues
- `pytest --cov=haclient --cov-fail-under=95` — **252 passed**, total coverage **96.31 %**, `lock.py` at **100 %**.