### PR TITLE
feat(domains): add Valve domain (#33)

### DIFF
--- a/src/haclient/domains/__init__.py
+++ b/src/haclient/domains/__init__.py
@@ -15,6 +15,7 @@ from haclient.domains.scene import Scene
 from haclient.domains.sensor import Sensor
 from haclient.domains.switch import Switch
 from haclient.domains.timer import Timer
+from haclient.domains.valve import Valve
 
 __all__ = [
     "BinarySensor",
@@ -29,4 +30,5 @@ __all__ = [
     "Sensor",
     "Switch",
     "Timer",
+    "Valve",
 ]

--- a/src/haclient/domains/valve.py
+++ b/src/haclient/domains/valve.py
@@ -1,0 +1,204 @@
+"""``valve`` domain implementation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from haclient.core.plugins import DomainSpec, register_domain
+from haclient.entity.base import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+# Home Assistant ``ValveEntityFeature`` bitmask.
+# See homeassistant/components/valve/const.py.
+_FEATURE_OPEN = 1
+_FEATURE_CLOSE = 2
+_FEATURE_SET_POSITION = 4
+_FEATURE_STOP = 8
+
+
+class Valve(Entity):
+    """A Home Assistant valve entity (water shutoff, gas, irrigation).
+
+    Mirrors the typed `Cover` shape because valves share the same
+    open/close/position model, but is exposed as a distinct domain to
+    preserve the safety-critical semantics of valves (water mains, gas
+    lines) and to match Home Assistant's separate ``valve`` domain
+    introduced in 2023.9.
+
+    Uses intent-specific action names (``open``, ``close``, ``stop``,
+    ``set_position``) rather than raw HA service names. The
+    ``set_position`` and ``stop`` actions degrade safely on valves that
+    only advertise binary open/close support: they log a debug message
+    and return without raising, so user code targeting a heterogeneous
+    fleet of valves does not break. Callers that need to know whether
+    the action will actually be dispatched can pre-check with
+    `supports_set_position` or `supports_stop`.
+    """
+
+    domain = "valve"
+
+    # -- Listener decorators ------------------------------------------
+
+    def on_open(self, func: Any) -> Any:
+        """Register a listener for when the valve opens.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``open`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_state_transition_listener("open", func)
+
+    def on_close(self, func: Any) -> Any:
+        """Register a listener for when the valve closes.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``closed`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_state_transition_listener("closed", func)
+
+    def on_position_change(self, func: Any) -> Any:
+        """Register a listener for position changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new ``current_position`` value
+            (0--100).
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_attr_listener("current_position", func)
+
+    # -- State properties ---------------------------------------------
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the valve is currently open."""
+        return self.state == "open"
+
+    @property
+    def is_closed(self) -> bool:
+        """Whether the valve is currently closed."""
+        return self.state == "closed"
+
+    @property
+    def is_opening(self) -> bool:
+        """Whether the valve is currently in the process of opening."""
+        return self.state == "opening"
+
+    @property
+    def is_closing(self) -> bool:
+        """Whether the valve is currently in the process of closing."""
+        return self.state == "closing"
+
+    @property
+    def current_position(self) -> int | None:
+        """Current position (0--100) or ``None`` if unsupported."""
+        value = self.attributes.get("current_position")
+        return int(value) if isinstance(value, (int, float)) else None
+
+    def _has_feature(self, mask: int) -> bool:
+        """Return ``True`` when ``supported_features`` advertises *mask*.
+
+        Parameters
+        ----------
+        mask : int
+            ``ValveEntityFeature`` bit to test for.
+
+        Returns
+        -------
+        bool
+            ``True`` if the entity advertises *mask* in its
+            ``supported_features`` bitmask, otherwise ``False``.
+        """
+        features = self.attributes.get("supported_features")
+        if not isinstance(features, int):
+            return False
+        return bool(features & mask)
+
+    @property
+    def supports_set_position(self) -> bool:
+        """Whether the valve advertises ``SET_POSITION`` support."""
+        return self._has_feature(_FEATURE_SET_POSITION)
+
+    @property
+    def supports_stop(self) -> bool:
+        """Whether the valve advertises ``STOP`` support."""
+        return self._has_feature(_FEATURE_STOP)
+
+    # -- Actions ------------------------------------------------------
+
+    async def open(self) -> None:
+        """Open the valve fully."""
+        await self._call_service("open_valve")
+
+    async def close(self) -> None:
+        """Close the valve fully."""
+        await self._call_service("close_valve")
+
+    async def stop(self) -> None:
+        """Stop movement of the valve, if supported.
+
+        Degrades safely: if the valve does not advertise the ``STOP``
+        feature, this method logs a debug message and returns without
+        raising. Callers can pre-check with `supports_stop`.
+        """
+        if not self.supports_stop:
+            _LOGGER.debug(
+                "stop() unsupported for %s; skipping (no ValveEntityFeature.STOP)",
+                self.entity_id,
+            )
+            return
+        await self._call_service("stop_valve")
+
+    async def set_position(self, position: int) -> None:
+        """Set the valve position, if supported.
+
+        Parameters
+        ----------
+        position : int
+            Target position (``0`` = fully closed, ``100`` = fully
+            open), coerced to ``int``.
+
+        Notes
+        -----
+        Degrades safely: if the valve does not advertise the
+        ``SET_POSITION`` feature (e.g. a binary water shutoff), this
+        method logs a debug message and returns without raising.
+        Callers can pre-check with `supports_set_position`.
+        """
+        if not self.supports_set_position:
+            _LOGGER.debug(
+                "set_position() unsupported for %s; skipping (no ValveEntityFeature.SET_POSITION)",
+                self.entity_id,
+            )
+            return
+        await self._call_service("set_valve_position", {"position": int(position)})
+
+    async def toggle(self) -> None:
+        """Toggle open/close state."""
+        await self._call_service("toggle")
+
+
+SPEC: DomainSpec[Valve] = register_domain(DomainSpec(name="valve", entity_cls=Valve))
+"""The `DomainSpec` registered with the shared `DomainRegistry`."""

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -748,3 +748,139 @@ async def test_lock_listeners(client: HAClient, fake_ha: FakeHA) -> None:
     assert locked == [("unlocked", "locked")]
     assert unlocked == [("locked", "unlocked")]
     assert jammed == [("locked", "jammed")]
+
+
+async def test_valve_actions_full_featured(client: HAClient, fake_ha: FakeHA) -> None:
+    """A full-featured valve dispatches every intent-specific service."""
+    valve = client.valve("main_water")
+    # All ValveEntityFeature bits: OPEN|CLOSE|SET_POSITION|STOP = 15.
+    valve._apply_state({"state": "open", "attributes": {"supported_features": 15}})
+
+    await valve.open()
+    await valve.close()
+    await valve.stop()
+    await valve.set_position(40)
+    await valve.toggle()
+
+    svc = [c["service"] for c in fake_ha.ws_service_calls]
+    assert svc == ["open_valve", "close_valve", "stop_valve", "set_valve_position", "toggle"]
+    assert all(c["domain"] == "valve" for c in fake_ha.ws_service_calls)
+    position_call = _find_call(fake_ha, "set_valve_position")
+    assert position_call["service_data"]["position"] == 40
+
+
+async def test_valve_state_properties(client: HAClient) -> None:
+    """State helpers reflect the underlying HA state and attributes."""
+    valve = client.valve("garden")
+
+    valve._apply_state({"state": "open", "attributes": {"current_position": 75}})
+    assert valve.is_open
+    assert not valve.is_closed
+    assert not valve.is_opening
+    assert not valve.is_closing
+    assert valve.current_position == 75
+
+    valve._apply_state({"state": "closed", "attributes": {}})
+    assert valve.is_closed
+    assert not valve.is_open
+    assert valve.current_position is None
+
+    valve._apply_state({"state": "opening", "attributes": {"current_position": 50.0}})
+    assert valve.is_opening
+    assert valve.current_position == 50
+
+    valve._apply_state({"state": "closing", "attributes": {"current_position": "bad"}})
+    assert valve.is_closing
+    assert valve.current_position is None
+
+
+async def test_valve_degrades_when_features_missing(client: HAClient, fake_ha: FakeHA) -> None:
+    """``set_position`` and ``stop`` no-op on binary valves; ``open``/``close`` still work."""
+    valve = client.valve("shutoff")
+    # OPEN|CLOSE only — no SET_POSITION, no STOP.
+    valve._apply_state({"state": "open", "attributes": {"supported_features": 3}})
+
+    assert valve.supports_set_position is False
+    assert valve.supports_stop is False
+
+    await valve.set_position(50)
+    await valve.stop()
+    assert fake_ha.ws_service_calls == []
+
+    await valve.open()
+    await valve.close()
+    svc = [c["service"] for c in fake_ha.ws_service_calls]
+    assert svc == ["open_valve", "close_valve"]
+
+    # Missing attribute entirely behaves the same.
+    valve._apply_state({"state": "open", "attributes": {}})
+    assert valve.supports_set_position is False
+    assert valve.supports_stop is False
+
+    # Non-int ``supported_features`` is treated as unsupported.
+    valve._apply_state({"state": "open", "attributes": {"supported_features": "15"}})
+    assert valve.supports_set_position is False
+    assert valve.supports_stop is False
+
+
+async def test_valve_supports_set_position_and_stop_when_advertised(
+    client: HAClient, fake_ha: FakeHA
+) -> None:
+    """Feature flags surface positional/stop support independently."""
+    valve = client.valve("irrigation")
+    # SET_POSITION only.
+    valve._apply_state({"state": "open", "attributes": {"supported_features": 4}})
+    assert valve.supports_set_position is True
+    assert valve.supports_stop is False
+    await valve.set_position(25)
+    await valve.stop()
+    svc = [c["service"] for c in fake_ha.ws_service_calls]
+    assert svc == ["set_valve_position"]
+
+    # STOP only.
+    fake_ha.ws_service_calls.clear()
+    valve._apply_state({"state": "open", "attributes": {"supported_features": 8}})
+    assert valve.supports_set_position is False
+    assert valve.supports_stop is True
+    await valve.set_position(25)
+    await valve.stop()
+    svc = [c["service"] for c in fake_ha.ws_service_calls]
+    assert svc == ["stop_valve"]
+
+
+async def test_valve_listeners(client: HAClient, fake_ha: FakeHA) -> None:
+    """``on_open`` / ``on_close`` / ``on_position_change`` fire as expected."""
+    valve = client.valve("zone1")
+    opened: list[tuple[Any, Any]] = []
+    closed: list[tuple[Any, Any]] = []
+    positions: list[Any] = []
+
+    @valve.on_open
+    def _on_open(old: Any, new: Any) -> None:
+        opened.append((old, new))
+
+    @valve.on_close
+    def _on_close(old: Any, new: Any) -> None:
+        closed.append((old, new))
+
+    @valve.on_position_change
+    def _on_position(old: Any, new: Any) -> None:
+        positions.append((old, new))
+
+    await fake_ha.push_state_changed(
+        "valve.zone1",
+        {"state": "closed", "attributes": {"current_position": 0}},
+        {"state": "open", "attributes": {"current_position": 100}},
+    )
+    await fake_ha.push_state_changed(
+        "valve.zone1",
+        {"state": "open", "attributes": {"current_position": 100}},
+        {"state": "closed", "attributes": {"current_position": 0}},
+    )
+    await asyncio.sleep(0.05)
+
+    assert opened == [("closed", "open")]
+    assert closed == [("open", "closed")]
+    # Position changes fire for both transitions (order is not guaranteed
+    # across distinct ``push_state_changed`` events).
+    assert sorted(positions) == [(0, 100), (100, 0)]


### PR DESCRIPTION
Closes #33. Recreated from closed #63 after a GitHub Actions outage (https://stspg.io/6gzfzr1dx684) prevented check-suite dispatch on the original PR.

## Validity assessment
**Valid feature request.** The `valve` domain (introduced in HA 2023.9) covers water shutoffs, gas valves, and irrigation zones. Without a typed helper, users had to fall back to raw service calls — inconsistent with the rest of the typed domain surface and especially risky for safety-critical valve operations. This aligns directly with the project's consistency-over-fidelity and explicit-intent principles.

## Fix
Added `src/haclient/domains/valve.py` modeled on `Cover` (matching open/close/position shape) with feature-gated degradation modeled on `Lock`:

- **State:** `is_open`, `is_closed`, `is_opening`, `is_closing`, `current_position`
- **Actions:** `open()`, `close()`, `stop()`, `set_position()`, `toggle()`
- **Listeners:** `on_open`, `on_close`, `on_position_change`
- **Graceful degradation:** `stop()` and `set_position()` check `supported_features` (`ValveEntityFeature.STOP` / `SET_POSITION`) and log + return on binary-only valves instead of raising. Pre-checks exposed via `supports_stop` / `supports_set_position`.

Registered with the shared `DomainRegistry` so `client.valve("main_water")` works without facade changes.

## Tests / checks run
- `pytest tests/ --cov=haclient --cov-report=term-missing --cov-fail-under=95` → **257 passed, 96.42% coverage** (valve.py at 100%)
- `ruff check src tests` → clean
- `ruff format --check src tests` → clean
- `mypy src` → clean (32 files)

New tests cover full-featured action dispatch, all state properties, feature-gated degradation for missing/non-int `supported_features`, independent SET_POSITION-only and STOP-only flags, and listener decorators.