### PR TITLE
feat(domains): add Humidifier domain (#38)

### DIFF
--- a/src/haclient/domains/__init__.py
+++ b/src/haclient/domains/__init__.py
@@ -8,6 +8,7 @@ unavailable; this is the basis for opt-in / opt-out loading.
 from haclient.domains.binary_sensor import BinarySensor
 from haclient.domains.climate import Climate
 from haclient.domains.cover import Cover
+from haclient.domains.humidifier import Humidifier
 from haclient.domains.light import Light
 from haclient.domains.lock import Lock
 from haclient.domains.media_player import FavoriteItem, MediaPlayer, NowPlaying
@@ -22,6 +23,7 @@ __all__ = [
     "Climate",
     "Cover",
     "FavoriteItem",
+    "Humidifier",
     "Light",
     "Lock",
     "MediaPlayer",

--- a/src/haclient/domains/humidifier.py
+++ b/src/haclient/domains/humidifier.py
@@ -1,0 +1,194 @@
+"""``humidifier`` domain implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from haclient.core.plugins import DomainSpec, register_domain
+from haclient.entity.base import Entity
+
+
+class Humidifier(Entity):
+    """A Home Assistant humidifier (or dehumidifier) entity.
+
+    The public API uses ``on()`` / ``off()`` / ``toggle()`` as
+    intent-specific names rather than the raw HA ``turn_on`` /
+    ``turn_off`` services, and exposes humidity-specific state and
+    actions.
+
+    Mode operations degrade safely: `set_mode` checks the entity's
+    reported `available_modes` and raises ``ValueError`` for unsupported
+    modes, while devices that do not report modes at all expose an
+    empty `available_modes` list and a `mode` of ``None``.
+    """
+
+    domain = "humidifier"
+
+    # -- Listener decorators ------------------------------------------
+
+    def on_turn_on(self, func: Any) -> Any:
+        """Register a listener for when the humidifier turns on.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``on`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_state_transition_listener("on", func)
+
+    def on_turn_off(self, func: Any) -> Any:
+        """Register a listener for when the humidifier turns off.
+
+        Parameters
+        ----------
+        func : callable
+            Sync or async zero-argument callable invoked on every
+            transition into the ``off`` state.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_state_transition_listener("off", func)
+
+    def on_humidity_change(self, func: Any) -> Any:
+        """Register a listener for target humidity changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new target ``humidity`` value.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_attr_listener("humidity", func)
+
+    def on_mode_change(self, func: Any) -> Any:
+        """Register a listener for operating mode changes.
+
+        Parameters
+        ----------
+        func : callable
+            Callable receiving the new mode string.
+
+        Returns
+        -------
+        callable
+            The same *func*, returned for decorator use.
+        """
+        return self._register_attr_listener("mode", func)
+
+    # -- State properties ---------------------------------------------
+
+    @property
+    def is_on(self) -> bool:
+        """Whether the humidifier is currently on."""
+        return self.state == "on"
+
+    @property
+    def target_humidity(self) -> int | None:
+        """Configured target humidity, in percent, if reported."""
+        value = self.attributes.get("humidity")
+        return int(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def current_humidity(self) -> int | None:
+        """Currently measured humidity, in percent.
+
+        Returns ``None`` when the device does not report a reading.
+        """
+        value = self.attributes.get("current_humidity")
+        return int(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def mode(self) -> str | None:
+        """Active operating mode, or ``None`` when the device has none."""
+        value = self.attributes.get("mode")
+        return str(value) if isinstance(value, str) else None
+
+    @property
+    def available_modes(self) -> list[str]:
+        """Operating modes supported by the device.
+
+        Returns an empty list when the device does not advertise modes.
+        """
+        modes = self.attributes.get("available_modes")
+        return [str(m) for m in modes] if isinstance(modes, list) else []
+
+    @property
+    def device_class(self) -> str | None:
+        """Device class (``"humidifier"`` or ``"dehumidifier"``)."""
+        value = self.attributes.get("device_class")
+        return str(value) if isinstance(value, str) else None
+
+    # -- Actions ------------------------------------------------------
+
+    async def on(self) -> None:
+        """Activate the humidifier."""
+        await self._call_service("turn_on")
+
+    async def off(self) -> None:
+        """Deactivate the humidifier."""
+        await self._call_service("turn_off")
+
+    async def toggle(self) -> None:
+        """Toggle the humidifier state."""
+        await self._call_service("toggle")
+
+    async def set_humidity(self, humidity: int) -> None:
+        """Set the target humidity, in percent.
+
+        Parameters
+        ----------
+        humidity : int
+            Target humidity between 0 and 100 (inclusive).
+
+        Raises
+        ------
+        ValueError
+            If *humidity* is outside the 0-100 range.
+        """
+        value = int(humidity)
+        if not 0 <= value <= 100:
+            raise ValueError("humidity must be between 0 and 100")
+        await self._call_service("set_humidity", {"humidity": value})
+
+    async def set_mode(self, mode: str) -> None:
+        """Set the operating mode, when supported.
+
+        Parameters
+        ----------
+        mode : str
+            Mode to activate. Must be one of `available_modes` when the
+            device reports any; the call is silently skipped for devices
+            that do not support modes at all (empty `available_modes`).
+
+        Raises
+        ------
+        ValueError
+            If the device reports `available_modes` and *mode* is not
+            in that list.
+        """
+        modes = self.available_modes
+        if not modes:
+            # Graceful degradation: device exposes no modes.
+            return
+        if mode not in modes:
+            raise ValueError(
+                f"mode {mode!r} not in available_modes {modes!r}",
+            )
+        await self._call_service("set_mode", {"mode": mode})
+
+
+SPEC: DomainSpec[Humidifier] = register_domain(DomainSpec(name="humidifier", entity_cls=Humidifier))
+"""The `DomainSpec` registered with the shared `DomainRegistry`."""

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -884,3 +884,104 @@ async def test_valve_listeners(client: HAClient, fake_ha: FakeHA) -> None:
     # Position changes fire for both transitions (order is not guaranteed
     # across distinct ``push_state_changed`` events).
     assert sorted(positions) == [(0, 100), (100, 0)]
+
+
+async def test_humidifier_actions(client: HAClient, fake_ha: FakeHA) -> None:
+    h = client.humidifier("bedroom")
+    await h.on()
+    await h.set_humidity(50)
+    await h.off()
+    await h.toggle()
+    calls = fake_ha.ws_service_calls
+    assert [c["service"] for c in calls] == ["turn_on", "set_humidity", "turn_off", "toggle"]
+    assert calls[1]["service_data"]["humidity"] == 50
+
+    h._apply_state(
+        {
+            "state": "on",
+            "attributes": {
+                "humidity": 45,
+                "current_humidity": 38,
+                "mode": "auto",
+                "available_modes": ["auto", "sleep", "baby"],
+                "device_class": "humidifier",
+            },
+        }
+    )
+    assert h.is_on
+    assert h.target_humidity == 45
+    assert h.current_humidity == 38
+    assert h.mode == "auto"
+    assert h.available_modes == ["auto", "sleep", "baby"]
+    assert h.device_class == "humidifier"
+
+    await h.set_mode("sleep")
+    assert fake_ha.ws_service_calls[-1]["service"] == "set_mode"
+    assert fake_ha.ws_service_calls[-1]["service_data"]["mode"] == "sleep"
+
+    with pytest.raises(ValueError):
+        await h.set_mode("nope")
+
+    with pytest.raises(ValueError):
+        await h.set_humidity(150)
+    with pytest.raises(ValueError):
+        await h.set_humidity(-1)
+
+
+async def test_humidifier_degrades_when_unsupported(client: HAClient, fake_ha: FakeHA) -> None:
+    h = client.humidifier("basement")
+    # Device reports no modes and no current humidity reading.
+    h._apply_state({"state": "off", "attributes": {}})
+    assert not h.is_on
+    assert h.target_humidity is None
+    assert h.current_humidity is None
+    assert h.mode is None
+    assert h.available_modes == []
+    assert h.device_class is None
+
+    # set_mode is a no-op when the device exposes no modes.
+    before = len(fake_ha.ws_service_calls)
+    await h.set_mode("auto")
+    assert len(fake_ha.ws_service_calls) == before
+
+
+async def test_humidifier_listeners(client: HAClient, fake_ha: FakeHA) -> None:
+    h = client.humidifier("nursery")
+
+    turned_on: list[tuple[Any, Any]] = []
+    turned_off: list[tuple[Any, Any]] = []
+    humidity_events: list[tuple[Any, Any]] = []
+    mode_events: list[tuple[Any, Any]] = []
+
+    @h.on_turn_on
+    def _on(old: Any, new: Any) -> None:
+        turned_on.append((old, new))
+
+    @h.on_turn_off
+    def _off(old: Any, new: Any) -> None:
+        turned_off.append((old, new))
+
+    @h.on_humidity_change
+    def _hum(old: Any, new: Any) -> None:
+        humidity_events.append((old, new))
+
+    @h.on_mode_change
+    def _mode(old: Any, new: Any) -> None:
+        mode_events.append((old, new))
+
+    await fake_ha.push_state_changed(
+        "humidifier.nursery",
+        {"state": "on", "attributes": {"humidity": 55, "mode": "sleep"}},
+        {"state": "off", "attributes": {"humidity": 40, "mode": "auto"}},
+    )
+    await fake_ha.push_state_changed(
+        "humidifier.nursery",
+        {"state": "off", "attributes": {"humidity": 55, "mode": "sleep"}},
+        {"state": "on", "attributes": {"humidity": 55, "mode": "sleep"}},
+    )
+
+    await asyncio.sleep(0.05)
+    assert turned_on == [("off", "on")]
+    assert turned_off == [("on", "off")]
+    assert humidity_events == [(40, 55)]
+    assert mode_events == [("auto", "sleep")]


### PR DESCRIPTION
Closes #38.

## Issue assessment

Valid feature request. The `humidifier` domain was the only HVAC-adjacent
Home Assistant domain without a typed wrapper. Adding it is consistent
with existing domains (Climate, Switch, Cover, Valve, Lock) and the
project's core mission of providing an intuitive, Pythonic abstraction
over HA's raw services.

## Fix

New `src/haclient/domains/humidifier.py` with:

- **State properties:** `is_on`, `target_humidity`, `current_humidity`,
  `mode`, `available_modes`, `device_class`.
- **Actions:** `on()`, `off()`, `toggle()`, `set_humidity(value)`,
  `set_mode(mode)`. `set_humidity` validates the 0-100 range.
- **Listeners:** `on_turn_on`, `on_turn_off`, `on_humidity_change`,
  `on_mode_change`.
- **Graceful degradation:** `set_mode` is a no-op when the device
  reports no `available_modes`, and raises `ValueError` for unknown
  modes when it does. `current_humidity`, `target_humidity`, `mode`,
  and `device_class` all return `None` when unreported.

Registered via the standard `DomainSpec` plugin mechanism, so
`client.humidifier("bedroom")` works automatically.

## Checks run

- `pytest tests/ --cov=haclient --cov-fail-under=95` — 260 passed,
  total coverage 96.52% (humidifier module 100%).
- `ruff check src tests` — clean.
- `ruff format --check src tests` — clean.
- `mypy src` — clean (strict mode, 33 source files).