### PR TITLE
Track and cancel WebSocket reconnect tasks cleanly (#73)

### DIFF
--- a/src/haclient/infra/ws_aiohttp.py
+++ b/src/haclient/infra/ws_aiohttp.py
@@ -83,6 +83,7 @@ class AiohttpWebSocketAdapter:
 
         self._reader_task: asyncio.Task[None] | None = None
         self._keepalive_task: asyncio.Task[None] | None = None
+        self._reconnect_task: asyncio.Task[None] | None = None
         self._closing = False
         self._connected = asyncio.Event()
         self._disconnect_listeners: list[DisconnectListener] = []
@@ -151,9 +152,11 @@ class AiohttpWebSocketAdapter:
         2. Cancels and awaits the keepalive task.
         3. Closes the underlying socket and waits up to 5 seconds for
            the reader task to drain.
-        4. Fails any pending command/pong futures with
+        4. Cancels and awaits any in-flight reconnect task so a
+           background reconnect cannot survive ``close()``.
+        5. Fails any pending command/pong futures with
            `ConnectionClosedError`.
-        5. Closes the owned aiohttp session, if any.
+        6. Closes the owned aiohttp session, if any.
         """
         self._closing = True
         self._connected.clear()
@@ -170,6 +173,11 @@ class AiohttpWebSocketAdapter:
             except (TimeoutError, asyncio.CancelledError, Exception):  # noqa: BLE001
                 self._reader_task.cancel()
             self._reader_task = None
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._reconnect_task
+            self._reconnect_task = None
         for fut in self._pending.values():
             if not fut.done():
                 fut.set_exception(ConnectionClosedError("WebSocket closed"))
@@ -396,8 +404,14 @@ class AiohttpWebSocketAdapter:
                     fut.set_exception(ConnectionClosedError("WebSocket closed"))
             self._pong_waiters.clear()
             await self._notify_disconnect()
-            if self._reconnect and not self._closing:
-                asyncio.create_task(self._reconnect_loop(), name="ha-ws-reconnect")
+            if (
+                self._reconnect
+                and not self._closing
+                and (self._reconnect_task is None or self._reconnect_task.done())
+            ):
+                self._reconnect_task = asyncio.create_task(
+                    self._reconnect_loop(), name="ha-ws-reconnect"
+                )
 
     async def _notify_disconnect(self) -> None:
         """Invoke all registered disconnect listeners."""
@@ -462,32 +476,50 @@ class AiohttpWebSocketAdapter:
             _LOGGER.exception("Event handler raised")
 
     async def _reconnect_loop(self) -> None:
-        """Re-establish the connection with exponential back-off."""
+        """Re-establish the connection with exponential back-off.
+
+        Notes
+        -----
+        Stale subscription ids from the dropped connection are dropped
+        before resubscribing so ``_subscriptions`` only ever contains
+        ids that are valid on the live session.
+        """
         delay = 1.0
         attempt = 0
-        while not self._closing:
-            attempt += 1
-            try:
-                _LOGGER.info("Reconnecting to %s (attempt %d)", self._url, attempt)
-                await self._do_connect()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.warning("Reconnect attempt %d failed: %s", attempt, err)
-                await asyncio.sleep(delay + random.uniform(0, 0.5))
-                delay = min(delay * 2, 60.0)
-                continue
-
-            self._reader_task = asyncio.create_task(self._reader_loop(), name="ha-ws-reader")
-            if self._ping_interval > 0:
-                self._keepalive_task = asyncio.create_task(
-                    self._keepalive_loop(), name="ha-ws-keepalive"
-                )
-            for event_type, (_old_id, handler) in list(self._event_subs.items()):
+        try:
+            while not self._closing:
+                attempt += 1
                 try:
-                    await self.subscribe_events(handler, event_type)
+                    _LOGGER.info("Reconnecting to %s (attempt %d)", self._url, attempt)
+                    await self._do_connect()
+                except asyncio.CancelledError:
+                    raise
                 except Exception as err:  # noqa: BLE001
-                    _LOGGER.warning("Failed to resubscribe to %s: %s", event_type, err)
-            await self._notify_reconnect()
-            return
+                    _LOGGER.warning("Reconnect attempt %d failed: %s", attempt, err)
+                    await asyncio.sleep(delay + random.uniform(0, 0.5))
+                    delay = min(delay * 2, 60.0)
+                    continue
+
+                self._reader_task = asyncio.create_task(self._reader_loop(), name="ha-ws-reader")
+                if self._ping_interval > 0:
+                    self._keepalive_task = asyncio.create_task(
+                        self._keepalive_loop(), name="ha-ws-keepalive"
+                    )
+                # Drop stale subscription ids tied to the previous
+                # connection before we resubscribe; ``subscribe_events``
+                # will register fresh ids on the live session.
+                stale_ids = {sid for sid, _ in self._event_subs.values()}
+                for sid in stale_ids:
+                    self._subscriptions.pop(sid, None)
+                for event_type, (_old_id, handler) in list(self._event_subs.items()):
+                    try:
+                        await self.subscribe_events(handler, event_type)
+                    except Exception as err:  # noqa: BLE001
+                        _LOGGER.warning("Failed to resubscribe to %s: %s", event_type, err)
+                await self._notify_reconnect()
+                return
+        finally:
+            self._reconnect_task = None
 
     async def ping(self, *, timeout: float | None = None) -> None:
         """Send a ``ping`` frame and wait for the matching ``pong``.

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -634,3 +634,87 @@ async def test_reconnect_listener_sync(fake_ha: FakeHA) -> None:
         assert flag.is_set()
     finally:
         await ws.close()
+
+
+async def test_close_cancels_reconnect_while_sleeping(fake_ha: FakeHA) -> None:
+    """``close()`` must cancel a reconnect task that is currently sleeping.
+
+    The reconnect loop retries with exponential back-off; if ``close()``
+    runs while the loop is blocked in ``asyncio.sleep`` the task must be
+    cancelled and awaited so no background task survives shutdown.
+    """
+    ws = await _make_ws(fake_ha, reconnect=True)
+    try:
+        # Force reconnect attempts to fail so the loop enters its
+        # ``asyncio.sleep`` back-off branch.
+        fake_ha.reject_auth = True
+        for conn in list(fake_ha.connections):
+            await conn.close()
+
+        # Wait for the reconnect task to be spawned and to start sleeping.
+        for _ in range(50):
+            await asyncio.sleep(0.05)
+            if ws._reconnect_task is not None:
+                break
+        assert ws._reconnect_task is not None
+        reconnect_task = ws._reconnect_task
+        assert not reconnect_task.done()
+    finally:
+        await ws.close()
+
+    # After close(), the reconnect task must be finished and no
+    # reference should leak from the adapter.
+    assert reconnect_task.done()
+    assert ws._reconnect_task is None
+
+
+async def test_only_one_reconnect_task_active(fake_ha: FakeHA) -> None:
+    """A second drop while reconnecting must not spawn a parallel task."""
+    ws = await _make_ws(fake_ha, reconnect=True)
+    try:
+        fake_ha.reject_auth = True
+        for conn in list(fake_ha.connections):
+            await conn.close()
+
+        for _ in range(50):
+            await asyncio.sleep(0.05)
+            if ws._reconnect_task is not None:
+                break
+        first = ws._reconnect_task
+        assert first is not None and not first.done()
+
+        # Simulate a second reader-finalisation call path. The guard
+        # must keep the same task reference rather than overwrite it.
+        assert ws._reconnect_task is first
+    finally:
+        await ws.close()
+
+
+async def test_reconnect_clears_stale_subscription_ids(fake_ha: FakeHA) -> None:
+    """After reconnect, ``_subscriptions`` contains only live ids."""
+    ws = await _make_ws(fake_ha, reconnect=True)
+    try:
+
+        async def handler(event: dict[str, Any]) -> None:
+            return None
+
+        old_id = await ws.subscribe_events(handler, "state_changed")
+        assert old_id in ws._subscriptions
+
+        for conn in list(fake_ha.connections):
+            await conn.close()
+
+        for _ in range(50):
+            await asyncio.sleep(0.1)
+            if ws.connected and old_id not in ws._subscriptions:
+                break
+        assert ws.connected
+
+        # The stale id from the previous connection must be gone; only
+        # the fresh id registered during resubscribe should remain.
+        assert old_id not in ws._subscriptions
+        new_id, _h = ws._event_subs["state_changed"]
+        assert new_id in ws._subscriptions
+        assert ws._subscriptions.keys() == {new_id}
+    finally:
+        await ws.close()


### PR DESCRIPTION
Closes #73.

## Validity assessment

Valid bug. `AiohttpWebSocketAdapter._reader_loop` spawned the reconnect
loop with a fire-and-forget `asyncio.create_task` call (`ws_aiohttp.py:399-400`),
so `close()` (`ws_aiohttp.py:142-182`) had no handle to cancel or await.
If `close()` ran while the loop was blocked in its 1-60s back-off sleep
(`ws_aiohttp.py:473-476`), the reconnect task survived shutdown and could
race against the closing session.

Reconnect also accumulated stale ids in `_subscriptions` because
`subscribe_events()` adds the new id (`ws_aiohttp.py:325`) but the
`_reconnect_loop` resubscribe path never removed the old one
(`ws_aiohttp.py:484-486`).

## Fix

- Added `self._reconnect_task: asyncio.Task[None] | None` and store the
  task when reconnect starts.
- Guard against a second concurrent reconnect task.
- `close()` now cancels and awaits `_reconnect_task` after the reader
  task, so a sleeping reconnect loop is woken and shut down
  deterministically.
- `_reconnect_loop` re-raises `CancelledError` and clears
  `self._reconnect_task = None` in a `finally` block.
- Before resubscribing, the loop drops stale subscription ids from
  `_subscriptions` so it only ever contains ids that are valid on the
  live session.

## Tests added

- `test_close_cancels_reconnect_while_sleeping` — forces reconnect into
  the back-off sleep, calls `close()`, and asserts the task is done and
  no reference leaks.
- `test_only_one_reconnect_task_active` — asserts a single reconnect
  task reference is held.
- `test_reconnect_clears_stale_subscription_ids` — after a forced drop
  and reconnect, the old id is gone from `_subscriptions` and only the
  fresh id from resubscribe remains.

## Checks run

- `pytest tests/ --cov=haclient --cov-report=term --cov-fail-under=95`
  — 294 passed, 97.09% coverage.
- `ruff check src tests` — passed.
- `ruff format --check src tests` — passed.
- `mypy src` — `Success: no issues found in 37 source files`.