### PR TITLE
fix: replace HTTP status string parsing with structured HTTPError

### DIFF
--- a/src/haclient/__init__.py
+++ b/src/haclient/__init__.py
@@ -33,6 +33,7 @@ from haclient.exceptions import (
     ConnectionClosedError,
     EntityNotFoundError,
     HAClientError,
+    HTTPError,
     TimeoutError,
 )
 from haclient.ports import Clock, RestPort, WebSocketPort
@@ -55,6 +56,7 @@ __all__ = [
     "EventBus",
     "HAClient",
     "HAClientError",
+    "HTTPError",
     "RestPort",
     "ServiceCaller",
     "ServicePolicy",

--- a/src/haclient/exceptions.py
+++ b/src/haclient/exceptions.py
@@ -36,6 +36,44 @@ class CommandError(HAClientError):
         self.message = message
 
 
+class HTTPError(HAClientError):
+    """Raised when Home Assistant returns an HTTP error response.
+
+    Parameters
+    ----------
+    status : int
+        The HTTP status code (e.g. 404, 500).
+    method : str
+        The HTTP method used (e.g. ``"GET"``).
+    path : str
+        The relative API path that was requested.
+    body : str
+        The response body text.
+
+    Attributes
+    ----------
+    status : int
+        The HTTP status code.
+    method : str
+        The HTTP method.
+    path : str
+        The relative API path.
+    body : str
+        The response body text.
+
+    Examples
+    --------
+    >>> raise HTTPError(404, "GET", "/api/states/light.missing", "not found")
+    """
+
+    def __init__(self, status: int, method: str, path: str, body: str) -> None:
+        super().__init__(f"HTTP {status} from {method} {path}: {body.strip()}")
+        self.status = status
+        self.method = method
+        self.path = path
+        self.body = body
+
+
 class TimeoutError(HAClientError):  # noqa: A001
     """Raised when a request to Home Assistant does not complete in time."""
 

--- a/src/haclient/infra/rest_aiohttp.py
+++ b/src/haclient/infra/rest_aiohttp.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import aiohttp
 
-from haclient.exceptions import AuthenticationError, HAClientError
+from haclient.exceptions import AuthenticationError, HAClientError, HTTPError
 from haclient.exceptions import TimeoutError as HATimeoutError
 
 _LOGGER = logging.getLogger(__name__)
@@ -110,8 +110,10 @@ class AiohttpRestAdapter:
         ------
         AuthenticationError
             On HTTP 401.
+        HTTPError
+            On any other HTTP error (status >= 400).
         HAClientError
-            On any other HTTP error or connection failure.
+            On connection failure.
         TimeoutError
             On request timeout.
         """
@@ -130,7 +132,7 @@ class AiohttpRestAdapter:
                     raise AuthenticationError("Invalid or expired access token")
                 if resp.status >= 400:
                     body = await resp.text()
-                    raise HAClientError(f"HTTP {resp.status} from {method} {path}: {body.strip()}")
+                    raise HTTPError(resp.status, method, path, body)
                 if resp.status == 200 and resp.content_type == "application/json":
                     return await resp.json()
                 return await resp.text()
@@ -182,11 +184,18 @@ class AiohttpRestAdapter:
         -------
         dict or None
             The state object, or ``None`` on HTTP 404.
+
+        Raises
+        ------
+        HTTPError
+            On any HTTP error other than 404.
+        AuthenticationError
+            On HTTP 401.
         """
         try:
             data = await self._request("GET", f"/api/states/{entity_id}")
-        except HAClientError as err:
-            if "HTTP 404" in str(err):
+        except HTTPError as err:
+            if err.status == 404:
                 return None
             raise
         if isinstance(data, dict):

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from haclient.exceptions import AuthenticationError, HAClientError
+from haclient.exceptions import AuthenticationError, HAClientError, HTTPError
 from haclient.infra.rest_aiohttp import AiohttpRestAdapter
 
 from .fake_ha import FakeHA
@@ -65,11 +65,68 @@ async def test_call_service_error(fake_ha: FakeHA) -> None:
 
 
 async def test_request_server_error(fake_ha: FakeHA) -> None:
-    """Trigger a non-auth error path by hitting an unknown REST endpoint."""
+    """Non-auth HTTP errors are raised as HTTPError (subclass of HAClientError)."""
     rc = AiohttpRestAdapter(fake_ha.base_url, fake_ha.token)
     try:
-        with pytest.raises(HAClientError):
+        with pytest.raises(HTTPError) as exc_info:
             await rc._request("GET", "/api/does-not-exist")
+        assert exc_info.value.status == 404
+        assert exc_info.value.method == "GET"
+        assert exc_info.value.path == "/api/does-not-exist"
+        # HTTPError is still a HAClientError
+        assert isinstance(exc_info.value, HAClientError)
+    finally:
+        await rc.close()
+
+
+async def test_http_error_attributes(fake_ha: FakeHA) -> None:
+    """HTTPError exposes status, method, path, and body as structured attributes."""
+    rc = AiohttpRestAdapter(fake_ha.base_url, fake_ha.token)
+    try:
+        with pytest.raises(HTTPError) as exc_info:
+            await rc._request("GET", "/api/does-not-exist")
+        err = exc_info.value
+        assert err.status == 404
+        assert err.method == "GET"
+        assert err.path == "/api/does-not-exist"
+        assert isinstance(err.body, str)
+        # String representation should include status code
+        assert "404" in str(err)
+    finally:
+        await rc.close()
+
+
+async def test_get_state_returns_none_only_for_404(fake_ha: FakeHA) -> None:
+    """get_state() returns None for a real 404, not for other HTTP errors."""
+    fake_ha.states = [{"entity_id": "light.kitchen", "state": "on", "attributes": {}}]
+    rc = AiohttpRestAdapter(fake_ha.base_url, fake_ha.token)
+    try:
+        # Known entity returns state dict
+        state = await rc.get_state("light.kitchen")
+        assert state is not None
+        assert state["state"] == "on"
+
+        # Unknown entity → 404 → None (not an exception)
+        missing = await rc.get_state("light.does_not_exist")
+        assert missing is None
+    finally:
+        await rc.close()
+
+
+async def test_get_state_reraises_non_404_http_error(
+    fake_ha: FakeHA, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """get_state() re-raises HTTPError for status codes other than 404."""
+    rc = AiohttpRestAdapter(fake_ha.base_url, fake_ha.token)
+
+    async def fake_request(method: str, path: str, **_: object) -> object:
+        raise HTTPError(500, method, path, "internal server error")
+
+    monkeypatch.setattr(rc, "_request", fake_request)
+    try:
+        with pytest.raises(HTTPError) as exc_info:
+            await rc.get_state("light.kitchen")
+        assert exc_info.value.status == 500
     finally:
         await rc.close()
 


### PR DESCRIPTION
Closes #79

## Validity Assessment

Valid bug. `get_state()` detected missing entities by parsing `"HTTP 404"` out of an exception message string. This is fragile: a message format change or a coincidental match in a response body could silently alter behavior. Status codes are structured data and should be treated as such.

## Fix

### New exception: `HTTPError`

Added `HTTPError(status, method, path, body)` to `exceptions.py`, derived from `HAClientError`. Carries the HTTP status code, method, path, and body as typed attributes. The `str()` representation is backward-compatible (`"HTTP 404 from GET /api/states/foo: ..."`).

```python
class HTTPError(HAClientError):
    def __init__(self, status: int, method: str, path: str, body: str) -> None: ...
    status: int
    method: str
    path: str
    body: str
```

`HTTPError` is exported from the top-level `haclient` package.

### `_request()` — `rest_aiohttp.py`

Raises `HTTPError` instead of generic `HAClientError` for all non-401 HTTP failures.

### `get_state()` — `rest_aiohttp.py`

Before:
```python
except HAClientError as err:
    if "HTTP 404" in str(err):  # brittle string match
        return None
```

After:
```python
except HTTPError as err:
    if err.status == 404:        # structured check
        return None
```

## Tests / Checks Run

- `test_request_server_error` — updated to assert the raised exception is `HTTPError` with correct `status`, `method`, `path` attributes, and that it is still an instance of `HAClientError`.
- `test_http_error_attributes` — new: verifies all structured attributes and the string representation.
- `test_get_state_returns_none_only_for_404` — new: verifies `get_state()` returns `None` only for a real 404, not for other scenarios.
- `test_get_state_reraises_non_404_http_error` — new: verifies `get_state()` re-raises `HTTPError` when status is not 404 (e.g. 500).

**Suite results:**
- `pytest`: 307 passed, coverage 97.16% (threshold 95%)
- `ruff check` + `ruff format --check`: all checks passed
- `mypy src`: no issues found