### PR TITLE
fix: normalize range validation for light, cover, and valve domains

### DIFF
--- a/src/haclient/domains/_utils.py
+++ b/src/haclient/domains/_utils.py
@@ -1,0 +1,42 @@
+"""Shared validation helpers for domain action methods."""
+
+from __future__ import annotations
+
+
+def validate_range(value: int, lo: int, hi: int, name: str) -> int:
+    """Coerce *value* to ``int`` and raise if it falls outside ``[lo, hi]``.
+
+    Parameters
+    ----------
+    value : int
+        The raw value supplied by the caller.
+    lo : int
+        Inclusive lower bound.
+    hi : int
+        Inclusive upper bound.
+    name : str
+        Human-readable parameter name used in the error message.
+
+    Returns
+    -------
+    int
+        The coerced integer, guaranteed to satisfy ``lo <= result <= hi``.
+
+    Raises
+    ------
+    ValueError
+        If the coerced value is less than *lo* or greater than *hi*.
+
+    Examples
+    --------
+    >>> validate_range(128, 0, 255, "brightness")
+    128
+    >>> validate_range(300, 0, 255, "brightness")
+    Traceback (most recent call last):
+        ...
+    ValueError: brightness must be between 0 and 255, got 300
+    """
+    coerced = int(value)
+    if not lo <= coerced <= hi:
+        raise ValueError(f"{name} must be between {lo} and {hi}, got {coerced}")
+    return coerced

--- a/src/haclient/domains/cover.py
+++ b/src/haclient/domains/cover.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from haclient.core.plugins import DomainSpec, register_domain
+from haclient.domains._utils import validate_range
 from haclient.entity.base import Entity, ValueChangeHandler
 
 
@@ -103,10 +104,18 @@ class Cover(Entity):
         Parameters
         ----------
         position : int
-            Target position, clamped/coerced to ``int``. ``0`` is fully
+            Target position in the range 0--100. ``0`` is fully
             closed; ``100`` is fully open.
+
+        Raises
+        ------
+        ValueError
+            If *position* is outside the 0--100 range.
         """
-        await self._call_service("set_cover_position", {"position": int(position)})
+        await self._call_service(
+            "set_cover_position",
+            {"position": validate_range(position, 0, 100, "position")},
+        )
 
     async def toggle(self) -> None:
         """Toggle open/close state."""

--- a/src/haclient/domains/light.py
+++ b/src/haclient/domains/light.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from haclient.core.plugins import DomainSpec, register_domain
+from haclient.domains._utils import validate_range
 from haclient.entity.base import Entity, ValueChangeHandler
 
 
@@ -151,12 +152,17 @@ class Light(Entity):
         Parameters
         ----------
         brightness : int
-            New brightness value, coerced to ``int``. ``0`` turns the
+            New brightness value in the range 0--255. ``0`` turns the
             light off; ``255`` is full brightness.
         transition : float or None, optional
             Seconds for the transition. Forwarded to HA when set.
+
+        Raises
+        ------
+        ValueError
+            If *brightness* is outside the 0--255 range.
         """
-        data: dict[str, Any] = {"brightness": int(brightness)}
+        data: dict[str, Any] = {"brightness": validate_range(brightness, 0, 255, "brightness")}
         if transition is not None:
             data["transition"] = transition
         await self._call_service("turn_on", data)
@@ -189,15 +195,25 @@ class Light(Entity):
         Parameters
         ----------
         r : int
-            Red component (0-255).
+            Red component (0--255).
         g : int
-            Green component (0-255).
+            Green component (0--255).
         b : int
-            Blue component (0-255).
+            Blue component (0--255).
         transition : float or None, optional
             Seconds for the transition. Forwarded to HA when set.
+
+        Raises
+        ------
+        ValueError
+            If any component is outside the 0--255 range.
         """
-        data: dict[str, Any] = {"rgb_color": [r, g, b]}
+        rgb = [
+            validate_range(r, 0, 255, "r"),
+            validate_range(g, 0, 255, "g"),
+            validate_range(b, 0, 255, "b"),
+        ]
+        data: dict[str, Any] = {"rgb_color": rgb}
         if transition is not None:
             data["transition"] = transition
         await self._call_service("turn_on", data)

--- a/src/haclient/domains/valve.py
+++ b/src/haclient/domains/valve.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from haclient.core.plugins import DomainSpec, register_domain
+from haclient.domains._utils import validate_range
 from haclient.entity.base import Entity, ValueChangeHandler
 
 _LOGGER = logging.getLogger(__name__)
@@ -176,8 +177,13 @@ class Valve(Entity):
         Parameters
         ----------
         position : int
-            Target position (``0`` = fully closed, ``100`` = fully
-            open), coerced to ``int``.
+            Target position in the range 0--100 (``0`` = fully closed,
+            ``100`` = fully open).
+
+        Raises
+        ------
+        ValueError
+            If *position* is outside the 0--100 range.
 
         Notes
         -----
@@ -185,14 +191,17 @@ class Valve(Entity):
         ``SET_POSITION`` feature (e.g. a binary water shutoff), this
         method logs a debug message and returns without raising.
         Callers can pre-check with `supports_set_position`.
+        Range validation always runs, even when the feature is absent,
+        so callers receive an immediate error for clearly invalid input.
         """
+        value = validate_range(position, 0, 100, "position")
         if not self.supports_set_position:
             _LOGGER.debug(
                 "set_position() unsupported for %s; skipping (no ValveEntityFeature.SET_POSITION)",
                 self.entity_id,
             )
             return
-        await self._call_service("set_valve_position", {"position": int(position)})
+        await self._call_service("set_valve_position", {"position": value})
 
     async def toggle(self) -> None:
         """Toggle open/close state."""

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1581,3 +1581,89 @@ async def test_fan_listeners(client: HAClient, fake_ha: FakeHA) -> None:
     assert turned_off == [("on", "off")]
     assert speed == [(0, 50), (50, 75), (75, 0)]
     assert direction == [("forward", "reverse"), ("reverse", "forward")]
+
+
+# ---------------------------------------------------------------------------
+# Range validation — issue #75
+# ---------------------------------------------------------------------------
+
+
+async def test_light_set_brightness_validation(client: HAClient, fake_ha: FakeHA) -> None:
+    """``set_brightness`` enforces the 0-255 range."""
+    light = client.light("kitchen")
+
+    with pytest.raises(ValueError, match="brightness"):
+        await light.set_brightness(-1)
+    with pytest.raises(ValueError, match="brightness"):
+        await light.set_brightness(256)
+
+    # Boundary values are accepted.
+    await light.set_brightness(0)
+    await light.set_brightness(255)
+    services = [c["service"] for c in fake_ha.ws_service_calls]
+    assert services == ["turn_on", "turn_on"]
+    assert fake_ha.ws_service_calls[0]["service_data"]["brightness"] == 0
+    assert fake_ha.ws_service_calls[1]["service_data"]["brightness"] == 255
+
+
+async def test_light_set_rgb_validation(client: HAClient, fake_ha: FakeHA) -> None:
+    """``set_rgb`` enforces the 0-255 range on each component."""
+    light = client.light("kitchen")
+
+    with pytest.raises(ValueError, match="r"):
+        await light.set_rgb(-1, 0, 0)
+    with pytest.raises(ValueError, match="r"):
+        await light.set_rgb(256, 0, 0)
+    with pytest.raises(ValueError, match="g"):
+        await light.set_rgb(0, -1, 0)
+    with pytest.raises(ValueError, match="g"):
+        await light.set_rgb(0, 256, 0)
+    with pytest.raises(ValueError, match="b"):
+        await light.set_rgb(0, 0, -1)
+    with pytest.raises(ValueError, match="b"):
+        await light.set_rgb(0, 0, 256)
+
+    # Boundary values are accepted.
+    await light.set_rgb(0, 0, 0)
+    await light.set_rgb(255, 255, 255)
+    assert fake_ha.ws_service_calls[0]["service_data"]["rgb_color"] == [0, 0, 0]
+    assert fake_ha.ws_service_calls[1]["service_data"]["rgb_color"] == [255, 255, 255]
+
+
+async def test_cover_set_position_validation(client: HAClient, fake_ha: FakeHA) -> None:
+    """``set_position`` enforces the 0-100 range."""
+    cv = client.cover("garage")
+
+    with pytest.raises(ValueError, match="position"):
+        await cv.set_position(-1)
+    with pytest.raises(ValueError, match="position"):
+        await cv.set_position(101)
+
+    # Boundary values are accepted.
+    await cv.set_position(0)
+    await cv.set_position(100)
+    services = [c["service"] for c in fake_ha.ws_service_calls]
+    assert services == ["set_cover_position", "set_cover_position"]
+    assert fake_ha.ws_service_calls[0]["service_data"]["position"] == 0
+    assert fake_ha.ws_service_calls[1]["service_data"]["position"] == 100
+
+
+async def test_valve_set_position_validation(client: HAClient, fake_ha: FakeHA) -> None:
+    """``set_position`` enforces the 0-100 range even when the feature is absent."""
+    valve = client.valve("main_water")
+
+    # Range validation fires regardless of feature support.
+    valve._apply_state({"state": "open", "attributes": {"supported_features": 0}})
+    with pytest.raises(ValueError, match="position"):
+        await valve.set_position(-1)
+    with pytest.raises(ValueError, match="position"):
+        await valve.set_position(101)
+
+    # With feature support, boundary values are accepted and dispatched.
+    valve._apply_state({"state": "open", "attributes": {"supported_features": 15}})
+    await valve.set_position(0)
+    await valve.set_position(100)
+    services = [c["service"] for c in fake_ha.ws_service_calls]
+    assert services == ["set_valve_position", "set_valve_position"]
+    assert fake_ha.ws_service_calls[0]["service_data"]["position"] == 0
+    assert fake_ha.ws_service_calls[1]["service_data"]["position"] == 100


### PR DESCRIPTION
Closes #75

## Issue validity

Valid and actionable. Four public action methods had inconsistent or missing numeric range validation, making the client's behaviour unpredictable and pushing input checking onto callers.

| Method | Documented range | Old behaviour | New behaviour |
|---|---|---|---|
| `light.set_brightness` | 0–255 | `int()` coerce only, no range check | Raises `ValueError` outside 0–255 |
| `light.set_rgb` | each component 0–255 | no coerce, no range check | Raises `ValueError` for any component outside 0–255 |
| `cover.set_position` | 0–100 | `int()` coerce only (docstring said "clamped") | Raises `ValueError` outside 0–100 |
| `valve.set_position` | 0–100 | no range check at all | Raises `ValueError` outside 0–100; validation runs before feature-support guard |

`fan.set_percentage`, `humidifier.set_humidity`, and `media_player.set_volume` already validated correctly and are unchanged.

## Fix

- Added `src/haclient/domains/_utils.py` with a single shared helper:
  ```python
  def validate_range(value: int, lo: int, hi: int, name: str) -> int
  ```
  Coerces to `int`, checks the closed interval, and raises `ValueError` with a consistent message (`"{name} must be between {lo} and {hi}, got {value}"`).

- Applied to `light.set_brightness`, `light.set_rgb` (all three components), `cover.set_position`, and `valve.set_position`.

- Docstrings updated with explicit `Raises` sections where missing.

## Tests

Four new test functions added to `tests/test_domains.py`:

- `test_light_set_brightness_validation` — below-range, above-range, boundary (0, 255)
- `test_light_set_rgb_validation` — below/above range for each of r, g, b; boundaries (0,0,0) and (255,255,255)
- `test_cover_set_position_validation` — below-range, above-range, boundary (0, 100)
- `test_valve_set_position_validation` — range validation fires even when feature is absent; boundaries dispatched when feature is present

## Checks run

- `pytest`: 311 passed, coverage 97.17% (threshold 95%)
- `ruff check` + `ruff format --check`: all passed
- `mypy src`: no issues