### PR TITLE
refactor: introduce typed SceneAccessor and TimerAccessor

### DIFF
--- a/src/haclient/api.py
+++ b/src/haclient/api.py
@@ -128,7 +128,8 @@ class HAClient:
         active = self._select_active_domains(domains)
         self._accessors: dict[str, DomainAccessor[Any]] = {}
         for spec in active:
-            accessor: DomainAccessor[Any] = DomainAccessor(spec, self._factory)
+            cls = spec.accessor_cls if spec.accessor_cls is not None else DomainAccessor
+            accessor: DomainAccessor[Any] = cls(spec, self._factory)
             self._accessors[spec.accessor_name()] = accessor
             self._accessors[spec.name] = accessor
             for event_type in spec.event_subscriptions:

--- a/src/haclient/core/plugins.py
+++ b/src/haclient/core/plugins.py
@@ -8,7 +8,13 @@ A `DomainAccessor` is the object returned by ``ha.<domain>`` (e.g.
 ``ha.light`` or ``ha.scene``). It provides:
 
 * ``__call__(name)`` and ``__getitem__(name)`` for entity lookup.
-* Domain-level operations registered by the spec via ``operations``.
+* Domain-level operations registered by the spec via ``operations`` (legacy
+  third-party path) **or** via typed subclass methods (preferred path).
+
+Domains with collection-level operations should subclass `DomainAccessor`
+and register the subclass via ``DomainSpec.accessor_cls``.  This keeps the
+public API statically typed without requiring ``# type: ignore`` workarounds
+or private ``_factory`` access from outside the accessor.
 
 Third-party plugins can ship additional domains by exposing an entry
 point under the ``haclient.domains`` group; see
@@ -63,10 +69,14 @@ class DomainSpec(Generic[E]):
     on_event : callable or None
         Per-domain event handler (see `DomainEventHandler`).
     operations : dict
-        Domain-level async operations registered on the
-        `DomainAccessor`. Each value is an async callable; it will be
-        bound to the accessor so the first positional argument *is* the
-        accessor instance.
+        Legacy dynamic operation dict kept for third-party plugin
+        compatibility. Built-in domains with collection-level operations
+        should prefer ``accessor_cls`` instead.
+    accessor_cls : type[DomainAccessor] or None
+        Optional typed `DomainAccessor` subclass to instantiate for this
+        domain. When provided, the ``HAClient`` uses this class rather than
+        the base `DomainAccessor`, exposing properly typed collection-level
+        methods (e.g. ``SceneAccessor.create``).
     """
 
     name: str
@@ -75,6 +85,7 @@ class DomainSpec(Generic[E]):
     event_subscriptions: tuple[str, ...] = ()
     on_event: DomainEventHandler | None = None
     operations: dict[str, Callable[..., Any]] = field(default_factory=dict)
+    accessor_cls: type[DomainAccessor[Any]] | None = None
 
     def accessor_name(self) -> str:
         """Return the accessor attribute name (defaults to ``name``)."""
@@ -87,14 +98,14 @@ class DomainAccessor(Generic[E]):
     Returned by ``HAClient.<accessor>``. Exposes:
 
     * Lookup by short name: ``ha.light("kitchen")`` or ``ha.light["kitchen"]``.
-    * Domain-level operations registered on the spec, bound to this accessor:
-      ``await ha.scene.create("romantic", ...)``.
+    * Domain-level operations either via typed subclass methods (preferred) or
+      via legacy dynamic binding of ``spec.operations`` entries.
 
     Parameters
     ----------
     spec : DomainSpec
         The spec describing this domain.
-    factory : EntityFactory
+    factory : EntityFactoryProtocol
         Factory used to create entity instances on demand.
     """
 
@@ -103,12 +114,22 @@ class DomainAccessor(Generic[E]):
         self._factory = factory
         for op_name, op in spec.operations.items():
             # Bind each operation as an attribute on the instance.
+            # This path is kept for backward-compatible third-party plugins.
             setattr(self, op_name, self._bind(op))
 
     @property
     def spec(self) -> DomainSpec[E]:
         """Return the underlying `DomainSpec`."""
         return self._spec
+
+    @property
+    def factory(self) -> EntityFactoryProtocol:
+        """Return the `EntityFactoryProtocol` used to create entities.
+
+        Subclasses use this to access ``factory.services`` and
+        ``factory.state`` without reaching into private internals.
+        """
+        return self._factory
 
     def _bind(self, op: Callable[..., Any]) -> Callable[..., Any]:
         """Bind a domain operation to this accessor.

--- a/src/haclient/domains/scene.py
+++ b/src/haclient/domains/scene.py
@@ -6,27 +6,23 @@ fire-and-forget: there is no ``turn_off`` counterpart.
 Domain-level operations
 -----------------------
 Beyond per-entity actions, the scene domain exposes two collection-level
-operations on the `DomainAccessor`:
+operations on the `SceneAccessor` (returned by ``ha.scene``):
 
-* ``create(scene_id, entities, *, snapshot_entities=None) -> Scene`` —
-  create (or update) a runtime scene helper.
-* ``apply(entities, *, transition=None) -> None`` — apply a state
-  combination without persisting it.
+* ``await ha.scene.create(scene_id, entities, *, snapshot_entities=None)``
+  — create (or update) a runtime scene helper, returning a `Scene`.
+* ``await ha.scene.apply(entities, *, transition=None)``
+  — apply a state combination without persisting it.
 
-These are invoked as ``await ha.scene.create(...)`` and
-``await ha.scene.apply(...)``. Per-entity access still works through the
-usual ``ha.scene("name")`` / ``ha.scene["name"]`` syntax.
+Per-entity access still works through the usual
+``ha.scene("name")`` / ``ha.scene["name"]`` syntax.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from haclient.core.plugins import DomainAccessor, DomainSpec, register_domain
 from haclient.entity.base import Entity, ValueChangeHandler
-
-if TYPE_CHECKING:
-    from haclient.core.factory import EntityFactory
 
 
 class Scene(Entity):
@@ -108,74 +104,82 @@ class Scene(Entity):
         return self._register_state_value_listener(func)
 
 
-# -- Domain-level operations --------------------------------------------
+# -- Typed domain accessor ----------------------------------------------
 
 
-async def _create(
-    accessor: DomainAccessor[Scene],
-    scene_id: str,
-    entities: dict[str, dict[str, Any]],
-    *,
-    snapshot_entities: list[str] | None = None,
-) -> Scene:
-    """Create a runtime scene and return the corresponding `Scene`.
+class SceneAccessor(DomainAccessor[Scene]):
+    """Typed domain accessor for the ``scene`` domain.
 
-    Parameters
-    ----------
-    accessor : DomainAccessor
-        The scene accessor (provided automatically by the binding).
-    scene_id : str
-        Object-id for the new scene (e.g. ``"romantic"`` →
-        ``scene.romantic``).
-    entities : dict
-        Mapping of entity ids to state/attribute dicts.
-    snapshot_entities : list of str or None, optional
-        Entity ids whose current state should be captured.
-
-    Returns
-    -------
-    Scene
-        The newly created scene.
+    Returned by ``ha.scene``. Provides statically-typed collection-level
+    operations in addition to the standard entity lookup methods inherited
+    from `DomainAccessor`.
     """
-    factory: EntityFactory = accessor._factory  # type: ignore[assignment]
-    services = factory.services
-    payload: dict[str, Any] = {"scene_id": scene_id, "entities": entities}
-    if snapshot_entities is not None:
-        payload["snapshot_entities"] = snapshot_entities
-    await services.call("scene", "create", payload)
-    return accessor[scene_id]
 
+    async def create(
+        self,
+        scene_id: str,
+        entities: dict[str, dict[str, Any]],
+        *,
+        snapshot_entities: list[str] | None = None,
+    ) -> Scene:
+        """Create (or update) a runtime scene helper.
 
-async def _apply(
-    accessor: DomainAccessor[Scene],
-    entities: dict[str, dict[str, Any]],
-    *,
-    transition: float | None = None,
-) -> None:
-    """Apply a scene-like state combination without persisting it.
+        Parameters
+        ----------
+        scene_id : str
+            Object-id for the new scene (e.g. ``"romantic"`` →
+            ``scene.romantic``).
+        entities : dict
+            Mapping of entity ids to target state/attribute dicts.
+        snapshot_entities : list of str or None, optional
+            Entity ids whose current state should be captured instead of
+            providing an explicit state dict.
 
-    Parameters
-    ----------
-    accessor : DomainAccessor
-        The scene accessor.
-    entities : dict
-        Mapping of entity ids to desired state/attribute dicts.
-    transition : float or None, optional
-        Transition seconds for entities that support it.
-    """
-    factory: EntityFactory = accessor._factory  # type: ignore[assignment]
-    services = factory.services
-    payload: dict[str, Any] = {"entities": entities}
-    if transition is not None:
-        payload["transition"] = transition
-    await services.call("scene", "apply", payload)
+        Returns
+        -------
+        Scene
+            The newly created (or updated) scene entity.
+        """
+        from haclient.core.factory import EntityFactory
+
+        factory = self.factory
+        assert isinstance(factory, EntityFactory)
+        payload: dict[str, Any] = {"scene_id": scene_id, "entities": entities}
+        if snapshot_entities is not None:
+            payload["snapshot_entities"] = snapshot_entities
+        await factory.services.call("scene", "create", payload)
+        return self[scene_id]
+
+    async def apply(
+        self,
+        entities: dict[str, dict[str, Any]],
+        *,
+        transition: float | None = None,
+    ) -> None:
+        """Apply a scene-like state combination without persisting it.
+
+        Parameters
+        ----------
+        entities : dict
+            Mapping of entity ids to desired state/attribute dicts.
+        transition : float or None, optional
+            Transition seconds for entities that support it.
+        """
+        from haclient.core.factory import EntityFactory
+
+        factory = self.factory
+        assert isinstance(factory, EntityFactory)
+        payload: dict[str, Any] = {"entities": entities}
+        if transition is not None:
+            payload["transition"] = transition
+        await factory.services.call("scene", "apply", payload)
 
 
 SPEC: DomainSpec[Scene] = register_domain(
     DomainSpec(
         name="scene",
         entity_cls=Scene,
-        operations={"create": _create, "apply": _apply},
+        accessor_cls=SceneAccessor,
     )
 )
 """The `DomainSpec` registered with the shared `DomainRegistry`."""

--- a/src/haclient/domains/timer.py
+++ b/src/haclient/domains/timer.py
@@ -21,7 +21,6 @@ from haclient.core.plugins import DomainAccessor, DomainSpec, register_domain
 from haclient.entity.base import Entity, ValueChangeHandler
 
 if TYPE_CHECKING:
-    from haclient.core.factory import EntityFactory
     from haclient.core.services import ServiceCaller
     from haclient.core.state import StateStore
     from haclient.ports import Clock
@@ -326,69 +325,79 @@ class Timer(Entity):
             self._schedule_value(listener, self.entity_id, data)
 
 
-# -- Domain-level operations & event handler --------------------------
+# -- Typed domain accessor & event handler ----------------------------
 
 
-async def _create(
-    accessor: DomainAccessor[Timer],
-    *,
-    name: str | None = None,
-    duration: str = "00:01:00",
-    persistent: bool = False,
-) -> Timer:
-    """Create a library-managed timer helper in Home Assistant.
+class TimerAccessor(DomainAccessor[Timer]):
+    """Typed domain accessor for the ``timer`` domain.
 
-    Sends a ``timer/create`` WebSocket command and returns a `Timer`.
-
-    Parameters
-    ----------
-    accessor : DomainAccessor
-        The timer accessor (provided automatically by the binding).
-    name : str or None, optional
-        Short object-id; auto-generated when omitted (only allowed for
-        ephemeral timers).
-    duration : str, optional
-        Initial duration for the helper.
-    persistent : bool, optional
-        If ``True``, the HA helper is **not** deleted on idle.
-        Requires an explicit *name*.
-
-    Returns
-    -------
-    Timer
-        The newly created timer entity.
-
-    Raises
-    ------
-    ValueError
-        If ``persistent=True`` and *name* is ``None``.
+    Returned by ``ha.timer``. Provides a statically-typed
+    :meth:`create` method in addition to the standard entity lookup
+    methods inherited from `DomainAccessor`.
     """
-    if name is None:
-        if persistent:
-            raise ValueError("Persistent timers require an explicit name")
-        name = _generate_timer_id()
 
-    factory: EntityFactory = accessor._factory  # type: ignore[assignment]
-    services = factory.services
-    state = factory.state
-    entity_id = state.registry.resolve("timer", name)
-    existing = state.registry.get(entity_id)
-    timer: Timer
-    if existing is not None and isinstance(existing, Timer):
-        timer = existing
-        if timer._ensured:
-            return timer
-    else:
-        timer = accessor[name]
+    async def create(
+        self,
+        *,
+        name: str | None = None,
+        duration: str = "00:01:00",
+        persistent: bool = False,
+    ) -> Timer:
+        """Create a library-managed timer helper in Home Assistant.
 
-    timer._persistent = persistent
-    object_id = entity_id.split(".", 1)[1]
-    await services.ws.send_command(
-        {"type": "timer/create", "name": object_id, "duration": duration}
-    )
-    timer._ensured = True
-    timer._created_by_us = True
-    return timer
+        Sends a ``timer/create`` WebSocket command and returns a `Timer`.
+
+        Parameters
+        ----------
+        name : str or None, optional
+            Short object-id; auto-generated when omitted (only allowed for
+            ephemeral timers).
+        duration : str, optional
+            Initial duration for the helper in HA format (e.g.
+            ``"00:01:00"``).
+        persistent : bool, optional
+            If ``True``, the HA helper is **not** deleted on idle.
+            Requires an explicit *name*.
+
+        Returns
+        -------
+        Timer
+            The newly created (or already-ensured) timer entity.
+
+        Raises
+        ------
+        ValueError
+            If ``persistent=True`` and *name* is ``None``.
+        """
+        from haclient.core.factory import EntityFactory
+
+        if name is None:
+            if persistent:
+                raise ValueError("Persistent timers require an explicit name")
+            name = _generate_timer_id()
+
+        factory = self.factory
+        assert isinstance(factory, EntityFactory)
+        services = factory.services
+        state = factory.state
+        entity_id = state.registry.resolve("timer", name)
+        existing = state.registry.get(entity_id)
+        timer: Timer
+        if existing is not None and isinstance(existing, Timer):
+            timer = existing
+            if timer._ensured:
+                return timer
+        else:
+            timer = self[name]
+
+        timer._persistent = persistent
+        object_id = entity_id.split(".", 1)[1]
+        await services.ws.send_command(
+            {"type": "timer/create", "name": object_id, "duration": duration}
+        )
+        timer._ensured = True
+        timer._created_by_us = True
+        return timer
 
 
 def _on_timer_event(entity: Entity, event_type: str, data: dict[str, Any]) -> None:
@@ -407,7 +416,7 @@ SPEC: DomainSpec[Timer] = register_domain(
         entity_cls=Timer,
         event_subscriptions=("timer.finished", "timer.cancelled"),
         on_event=_on_timer_event,
-        operations={"create": _create},
+        accessor_cls=TimerAccessor,
     )
 )
 """The `DomainSpec` registered with the shared `DomainRegistry`."""

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -199,3 +199,74 @@ async def test_domain_accessor_spec_property() -> None:
         assert accessor.spec.name == "light"
     finally:
         await ha.close()
+
+
+async def test_domain_accessor_factory_property() -> None:
+    """``DomainAccessor.factory`` returns the EntityFactoryProtocol instance."""
+    from haclient.core.factory import EntityFactory
+
+    ha = HAClient.from_url("http://x", token="t", load_plugins=False)
+    try:
+        accessor = ha.domain("light")
+        assert isinstance(accessor.factory, EntityFactory)
+    finally:
+        await ha.close()
+
+
+async def test_scene_accessor_is_typed_subclass() -> None:
+    """``ha.scene`` returns a ``SceneAccessor`` with typed methods."""
+    from haclient.domains.scene import SceneAccessor
+
+    ha = HAClient.from_url("http://x", token="t", load_plugins=False)
+    try:
+        accessor = ha.domain("scene")
+        assert isinstance(accessor, SceneAccessor)
+        assert callable(accessor.create)
+        assert callable(accessor.apply)
+    finally:
+        await ha.close()
+
+
+async def test_timer_accessor_is_typed_subclass() -> None:
+    """``ha.timer`` returns a ``TimerAccessor`` with a typed ``create`` method."""
+    from haclient.domains.timer import TimerAccessor
+
+    ha = HAClient.from_url("http://x", token="t", load_plugins=False)
+    try:
+        accessor = ha.domain("timer")
+        assert isinstance(accessor, TimerAccessor)
+        assert callable(accessor.create)
+    finally:
+        await ha.close()
+
+
+async def test_accessor_cls_in_spec_is_used() -> None:
+    """When ``DomainSpec.accessor_cls`` is set, it is instantiated by the client."""
+
+    class _CustomAccessor(DomainAccessor[_Custom]):
+        def special(self) -> str:
+            return "typed"
+
+    reg = DomainRegistry()
+    spec = DomainSpec(name="cls_test", entity_cls=_Custom, accessor_cls=_CustomAccessor)
+    reg.register(spec)
+    ha = HAClient.from_url("http://x", token="t", load_plugins=False, registry=reg)
+    try:
+        accessor = ha.domain("cls_test")
+        assert isinstance(accessor, _CustomAccessor)
+        assert accessor.special() == "typed"
+    finally:
+        await ha.close()
+
+
+async def test_accessor_cls_none_falls_back_to_base() -> None:
+    """When ``DomainSpec.accessor_cls`` is ``None``, the base ``DomainAccessor`` is used."""
+    reg = DomainRegistry()
+    spec = DomainSpec(name="base_test", entity_cls=_Custom)
+    reg.register(spec)
+    ha = HAClient.from_url("http://x", token="t", load_plugins=False, registry=reg)
+    try:
+        accessor = ha.domain("base_test")
+        assert type(accessor) is DomainAccessor
+    finally:
+        await ha.close()


### PR DESCRIPTION
Closes #76

## Issue validity

Valid and actionable. The issue correctly identifies that:
- `DomainSpec.operations` (`dict[str, Callable[..., Any]]`) and dynamic `setattr` binding make collection-level domain operations invisible to type checkers.
- Both `scene.py` and `timer.py` worked around this by accessing the private `accessor._factory` with `# type: ignore[assignment]`, bypassing encapsulation.
- The project ships `py.typed` and runs `mypy` in strict mode, so this is a genuine gap.

## Fix

### `core/plugins.py`
- Added `accessor_cls: type[DomainAccessor[Any]] | None = None` field to `DomainSpec`. Domains with collection-level operations declare their typed accessor subclass here instead of populating `operations`.
- Added `DomainAccessor.factory` as a **public property** returning the `EntityFactoryProtocol`. Subclasses use this to reach `factory.services` and `factory.state` without touching `_factory`.

### `api.py`
- `HAClient.__init__` now instantiates `spec.accessor_cls` when set, falling back to the base `DomainAccessor` for domains that don't need collection-level operations.

### `domains/scene.py`
- Replaced free functions `_create` / `_apply` + `operations={...}` with a `SceneAccessor(DomainAccessor[Scene])` subclass exposing typed `async def create(...) -> Scene` and `async def apply(...) -> None` methods.
- `DomainSpec` now uses `accessor_cls=SceneAccessor`.

### `domains/timer.py`
- Replaced free function `_create` + `operations={...}` with a `TimerAccessor(DomainAccessor[Timer])` subclass exposing a typed `async def create(...) -> Timer` method.
- `DomainSpec` now uses `accessor_cls=TimerAccessor`.
- All `# type: ignore[assignment]` comments removed.

## Tests added (`tests/test_plugins.py`)

| Test | What it verifies |
|---|---|
| `test_domain_accessor_factory_property` | `DomainAccessor.factory` returns an `EntityFactory` instance |
| `test_scene_accessor_is_typed_subclass` | `ha.scene` is a `SceneAccessor` with callable `create` and `apply` |
| `test_timer_accessor_is_typed_subclass` | `ha.timer` is a `TimerAccessor` with a callable `create` |
| `test_accessor_cls_in_spec_is_used` | Custom `accessor_cls` on a spec is correctly instantiated |
| `test_accessor_cls_none_falls_back_to_base` | Specs without `accessor_cls` get the base `DomainAccessor` |

## Validation

- `pytest tests/ --cov=haclient --cov-fail-under=95`: **316 passed**, coverage **97.11%**
- `ruff check src tests`: **All checks passed**
- `ruff format --check src tests`: **57 files already formatted**
- `mypy src`: **Success: no issues found in 38 source files**
