### PR TITLE
refactor: remove unused SharedSession helper (#77)

### DIFF
--- a/src/haclient/config.py
+++ b/src/haclient/config.py
@@ -1,8 +1,8 @@
 """Configuration objects for `HAClient`.
 
-The connection settings, URL handling, and aiohttp session ownership are
-captured in `ConnectionConfig`. This isolates configuration parsing from
-the rest of the package and keeps `HAClient.__init__` boring.
+The connection settings and URL handling are captured in
+`ConnectionConfig`. This isolates configuration parsing from the rest of
+the package and keeps `HAClient.__init__` boring.
 """
 
 from __future__ import annotations
@@ -10,8 +10,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 from urllib.parse import urlparse, urlunparse
-
-import aiohttp
 
 ServicePolicy = Literal["ws", "rest", "auto"]
 """How `ServiceCaller` should choose between WebSocket and REST.
@@ -126,25 +124,3 @@ class ConnectionConfig:
             verify_ssl=verify_ssl,
             service_policy=service_policy,
         )
-
-
-class SharedSession:
-    """Holder for an optional shared `aiohttp.ClientSession`.
-
-    Both REST and WebSocket adapters can use the same session instance,
-    which is the recommended pattern for users who already manage their
-    own ``aiohttp.ClientSession``. When no session is provided here, each
-    adapter creates and owns its own.
-    """
-
-    def __init__(self, session: aiohttp.ClientSession | None = None) -> None:
-        """Wrap *session* and record whether it was externally owned.
-
-        Parameters
-        ----------
-        session : aiohttp.ClientSession or None, optional
-            Pre-existing session to share between transports. ``None``
-            leaves each adapter to manage its own session.
-        """
-        self.session = session
-        self.shared = session is not None


### PR DESCRIPTION
Closes #77.

## Issue assessment

Valid and actionable. Verified that `SharedSession` (defined at `src/haclient/config.py:131-150` on `main`) has no importers or instantiations anywhere in the codebase or test suite. Session ownership lives directly inside `AiohttpRestAdapter` and `AiohttpWebSocketAdapter`, so the helper was pure dead code, and was the only reason `config.py` imported `aiohttp`.

## Fix

- Deleted the `SharedSession` class from `src/haclient/config.py`.
- Removed the now-unused `import aiohttp`.
- Updated the module docstring to drop the stale reference to "aiohttp session ownership".

No production code paths or public re-exports change (`SharedSession` was never exported from `haclient.__init__`).

## Checks run

- `ruff check src tests` — clean
- `ruff format --check src tests` — clean (57 files already formatted)
- `mypy src` — Success: no issues found in 38 source files
- `pytest tests/ --cov=haclient --cov-report=term-missing --cov-fail-under=95` — **316 passed**, coverage **97.18%** (above the 95% gate)