### PR TITLE
fix: single-source __version__ from package metadata (#78)

### DIFF
--- a/src/haclient/__init__.py
+++ b/src/haclient/__init__.py
@@ -12,6 +12,9 @@ Custom domains can be added by registering a `DomainSpec` via
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from haclient.api import HAClient
 from haclient.config import ConnectionConfig, ServicePolicy
 from haclient.core.connection import Connection
@@ -67,4 +70,7 @@ __all__ = [
     "register_domain",
 ]
 
-__version__ = "0.2.0"
+try:
+    __version__ = _pkg_version("haclient")
+except PackageNotFoundError:  # pragma: no cover - only hit when package not installed
+    __version__ = "0.0.0+unknown"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,26 @@
+"""Packaging metadata tests.
+
+Ensures the package version is single-sourced from installed metadata
+(see issue #78).
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version as pkg_version
+
+import haclient
+
+
+def test_version_matches_package_metadata() -> None:
+    """``haclient.__version__`` must match installed package metadata.
+
+    This guards against the previous drift where ``pyproject.toml`` and
+    ``haclient/__init__.py`` declared different versions.
+    """
+    assert haclient.__version__ == pkg_version("haclient")
+
+
+def test_version_is_non_empty_string() -> None:
+    """``__version__`` must be a non-empty string."""
+    assert isinstance(haclient.__version__, str)
+    assert haclient.__version__


### PR DESCRIPTION
Closes #78.

## Issue validity

**Valid.** Confirmed the drift firsthand:
- `pyproject.toml` declared version `1.1.2`
- `src/haclient/__init__.py` exposed `__version__ = "0.2.0"`

This is exactly the inconsistency the issue called out.

## Fix

Took option 1 from the issue's suggested fixes: keep `haclient.__version__` (no breaking change for users) but derive it at import time from installed package metadata, so `pyproject.toml` is the single source of truth.

```python
from importlib.metadata import PackageNotFoundError
from importlib.metadata import version as _pkg_version

try:
    __version__ = _pkg_version("haclient")
except PackageNotFoundError:  # pragma: no cover
    __version__ = "0.0.0+unknown"
```

Fallback only triggers if the package is not installed (e.g. running from a raw source tree without `pip install`).

## Tests

Added `tests/test_packaging.py`:
- `test_version_matches_package_metadata` — asserts `haclient.__version__ == importlib.metadata.version("haclient")`, preventing future drift.
- `test_version_is_non_empty_string` — sanity check.

## Checks run

- `ruff check src tests` — pass
- `ruff format --check src tests` — pass
- `mypy src` (strict) — pass, no issues in 38 source files
- `pytest tests/ --cov=haclient --cov-fail-under=95` — **318 passed**, coverage **97.18%**

Verified locally:

```
pkg meta:    1.1.2
__version__: 1.1.2
```
