### PR TITLE
docs: refine project description and expand keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-brightgreen?logo=dependabot)](https://github.com/graphras-com/HaClient/network/updates)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-Async-first, high-level Python client for Home Assistant with REST and WebSocket support. Provides typed domain accessors, real-time state tracking, automatic reconnection, and a synchronous wrapper for scripts and REPL use.
+A high-level typed Python SDK for building applications on top of the Home Assistant REST and WebSocket APIs.
+
+Unlike low-level Home Assistant clients that expose raw service calls and entity state payloads, this library provides domain-oriented accessors and intent-driven APIs designed for application development.
 
 **[Documentation](https://graphras-com.github.io/HaClient/)**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,33 @@ build-backend = "hatchling.build"
 [project]
 name = "haclient"
 dynamic = ["version"]
-description = "Async-first, high-level Python client for Home Assistant (REST + WebSocket)."
+description = "A high-level typed Python SDK for building applications on top of the Home Assistant REST and WebSocket APIs."
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 authors = [{ name = "HAClient Contributors" }]
-keywords = ["home-assistant", "homeassistant", "async", "websocket", "iot"]
+keywords = [
+  "home-assistant",
+  "homeassistant",
+  "python",
+  "asyncio",
+  "websocket",
+  "rest-api",
+  "smart-home",
+  "automation",
+  "typed",
+  "mypy",
+  "reactive",
+  "sdk",
+  "async",
+  "pep561",
+  "realtime",
+  "event-driven",
+  "iot",
+  "home-automation",
+  "typed-python",
+  "domain-driven"
+]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Framework :: AsyncIO",


### PR DESCRIPTION
## Summary

- Reframe README intro to position HaClient as a high-level typed SDK for building applications on top of Home Assistant, contrasting with low-level clients.
- Update `pyproject.toml` description to match.
- Expand `keywords` list in `pyproject.toml` for better PyPI discoverability (sdk, typed, asyncio, rest-api, smart-home, automation, reactive, event-driven, pep561, etc.).

## Test plan

- `pytest tests/ --cov=haclient --cov-fail-under=95` — 329 passed, 97.19% coverage.