### PR TITLE
docs: correct request_timeout default in README (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Create a client with `HAClient.from_url()` or by passing a `ConnectionConfig` di
 - **`token`** -- Long-lived access token generated from the Home Assistant UI
 - **`reconnect`** -- Enable automatic WebSocket reconnection (default: `True`)
 - **`ping_interval`** -- WebSocket keepalive interval in seconds (default: `30`)
-- **`request_timeout`** -- Timeout for REST and WS commands in seconds (default: `10`)
+- **`request_timeout`** -- Timeout for REST and WS commands in seconds (default: `30`)
 - **`verify_ssl`** -- Verify SSL certificates (default: `True`)
 - **`service_policy`** -- Service call routing: `"ws"`, `"rest"`, or `"auto"` (default: `"auto"`)
 


### PR DESCRIPTION
Closes #93

## Issue validity assessment

Valid and actionable. Verified the documented default in `README.md` (`10`) does not match the actual default in code (`30.0`) across all public construction paths:

- `ConnectionConfig.request_timeout` (src/haclient/config.py:73)
- `ConnectionConfig.from_url()` (src/haclient/config.py:86)
- `HAClient.from_url()` (src/haclient/api.py:150)
- `SyncHAClient.from_url()` (src/haclient/sync.py:208)

Other docs (`docs/guides/lifecycle.md`, `docs/guides/sync-wrapper.md`) already reflect the correct value; only the README was wrong.

## Fix

One-line change in `README.md`: `10` -> `30`.

The issue's optional suggestion of adding a config summary to `docs/index.md` was deferred — it is a docs-shape change beyond the scope of the bug, and the existing per-guide docs already document timeout behavior consistently with the code.

## Checks run

- `ruff check src tests` — passed
- `ruff format --check src tests` — passed (60 files)
- `mypy src` — passed (38 files, strict)
- `pytest tests/ --cov=haclient --cov-fail-under=95` — 329 passed, 97.19% coverage