### PR TITLE
docs: expose public package surface in API overview

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,5 +1,41 @@
 # API Reference
 
+The `haclient` package re-exports its public API at the top level. The
+table below maps every name in `haclient.__all__` to the reference page
+where it is documented.
+
+## Public exports
+
+| Name | Kind | Reference |
+| --- | --- | --- |
+| `HAClient` | Async client facade | [HAClient (facade)](api.md) |
+| `SyncHAClient` | Blocking wrapper | [Sync Client](sync.md) |
+| `ConnectionConfig` | Configuration | [Configuration](config.md) |
+| `ServicePolicy` | Configuration | [Configuration](config.md) |
+| `Entity` | Entity base class | [Entity](entity.md) |
+| `Connection` | Core | [Connection](core/connection.md) |
+| `EventBus` | Core | [Event Bus](core/events.md) |
+| `ServiceCaller` | Core | [Service Caller](core/services.md) |
+| `StateStore` | Core | [State Store](core/state.md) |
+| `EntityRegistry` | Core | [Entity Registry](core/registry.md) |
+| `EntityFactory` | Core | [Entity Factory](core/factory.md) |
+| `DomainAccessor` | Plugins | [Plugins](core/plugins.md) |
+| `DomainRegistry` | Plugins | [Plugins](core/plugins.md) |
+| `DomainSpec` | Plugins | [Plugins](core/plugins.md) |
+| `register_domain` | Plugins | [Plugins](core/plugins.md) |
+| `Clock` | Port protocol | [Ports](ports.md) |
+| `RestPort` | Port protocol | [Ports](ports.md) |
+| `WebSocketPort` | Port protocol | [Ports](ports.md) |
+| `HAClientError` | Exception | [Exceptions](exceptions.md) |
+| `AuthenticationError` | Exception | [Exceptions](exceptions.md) |
+| `CommandError` | Exception | [Exceptions](exceptions.md) |
+| `ConnectionClosedError` | Exception | [Exceptions](exceptions.md) |
+| `EntityNotFoundError` | Exception | [Exceptions](exceptions.md) |
+| `HTTPError` | Exception | [Exceptions](exceptions.md) |
+| `TimeoutError` | Exception | [Exceptions](exceptions.md) |
+
+## Package
+
 ::: haclient
     options:
       show_submodules: false


### PR DESCRIPTION
Closes #94

## Issue validity

**Valid.** `docs/reference/index.md` rendered the top-level `haclient` package with `show_submodules: false` and `members: false`, hiding the public import contract defined by `haclient/__init__.py` (`__all__`). Users had no discoverable overview of common imports like `HAClient`, `SyncHAClient`, `ConnectionConfig`, `DomainSpec`, `Entity`, or the exception types.

## Fix

Following the issue's suggested option of a hand-written table (keeps the page focused and avoids duplicating per-symbol docs that already live on dedicated reference pages):

- Added a table in `docs/reference/index.md` mapping every name in `haclient.__all__` to the reference page where it is documented.
- Kept the existing `::: haclient` block for the package-level docstring.

## Checks run

- `pytest tests/ --cov=haclient --cov-report=term-missing --cov-fail-under=95` — 329 passed, coverage 97.19%
- `ruff check src tests` — all checks passed
- `ruff format --check src tests` — 60 files already formatted
- `mypy src` — no issues in 38 source files
- `mkdocs build` — built cleanly